### PR TITLE
Make `batch_size` for Presto flexible

### DIFF
--- a/src/worldcereal/openeo/feature_extractor.py
+++ b/src/worldcereal/openeo/feature_extractor.py
@@ -19,7 +19,7 @@ class PrestoFeatureExtractor(PatchFeatureExtractor):
     """
 
     PRESTO_MODEL_URL = "https://artifactory.vgt.vito.be/artifactory/auxdata-public/worldcereal-minimal-inference/presto.pt"  # NOQA
-    PRESO_WHL_URL = "https://artifactory.vgt.vito.be/artifactory/auxdata-public/worldcereal/dependencies/presto_worldcereal-0.1.0-py3-none-any.whl"
+    PRESO_WHL_URL = "https://artifactory.vgt.vito.be/artifactory/auxdata-public/worldcereal/dependencies/presto_worldcereal-0.1.1-py3-none-any.whl"
     BASE_URL = "https://s3.waw3-1.cloudferro.com/swift/v1/project_dependencies"  # NOQA
     DEPENDENCY_NAME = "worldcereal_deps.zip"
 
@@ -103,7 +103,9 @@ class PrestoFeatureExtractor(PatchFeatureExtractor):
         )
 
         self.logger.info("Extracting presto features")
-        features = get_presto_features(inarr, presto_model_url, self.epsg)
+        features = get_presto_features(
+            inarr, presto_model_url, self.epsg, batch_size=4096
+        )
         return features
 
     def _execute(self, cube: XarrayDataCube, parameters: dict) -> XarrayDataCube:


### PR DESCRIPTION
`presto-worldcereal` wheel was updated and `get_presto_features` now accepts an optional `batch_size` parameter. In this PR, it's now set to 4096 (but not yet tested). Idea is that we can see what works best for our case.