### PR TITLE
Now writing GeoTiff and having two bands: binary mask and probabilities

### DIFF
--- a/scripts/inference/cropland_mapping.py
+++ b/scripts/inference/cropland_mapping.py
@@ -8,6 +8,7 @@ from openeo_gfmap import BoundingBoxExtent, TemporalContext
 from openeo_gfmap.backend import Backend, BackendContext
 from openeo_gfmap.features.feature_extractor import apply_feature_extractor
 from openeo_gfmap.inference.model_inference import apply_model_inference
+from openeo_gfmap.preprocessing.scaling import compress_uint16
 
 from worldcereal.openeo.feature_extractor import PrestoFeatureExtractor
 from worldcereal.openeo.inference import CroplandClassifier
@@ -104,6 +105,9 @@ if __name__ == "__main__":
             {"dimension": "y", "unit": "px", "value": 0},
         ],
     )
+
+    # Cast to uint16
+    classes = compress_uint16(classes)
 
     classes.execute_batch(
         outputfile=args.output_path,

--- a/scripts/inference/cropland_mapping.py
+++ b/scripts/inference/cropland_mapping.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
 
     classes.execute_batch(
         outputfile=args.output_path,
-        out_format="NetCDF",
+        out_format="GTiff",
         job_options={
             "driver-memory": "4g",
             "executor-memoryOverhead": "12g",

--- a/scripts/inference/cropland_mapping.py
+++ b/scripts/inference/cropland_mapping.py
@@ -8,7 +8,7 @@ from openeo_gfmap import BoundingBoxExtent, TemporalContext
 from openeo_gfmap.backend import Backend, BackendContext
 from openeo_gfmap.features.feature_extractor import apply_feature_extractor
 from openeo_gfmap.inference.model_inference import apply_model_inference
-from openeo_gfmap.preprocessing.scaling import compress_uint16
+from openeo_gfmap.preprocessing.scaling import compress_uint8
 
 from worldcereal.openeo.feature_extractor import PrestoFeatureExtractor
 from worldcereal.openeo.inference import CroplandClassifier
@@ -106,8 +106,8 @@ if __name__ == "__main__":
         ],
     )
 
-    # Cast to uint16
-    classes = compress_uint16(classes)
+    # Cast to uint8
+    classes = compress_uint8(classes)
 
     classes.execute_batch(
         outputfile=args.output_path,

--- a/src/worldcereal/openeo/inference.py
+++ b/src/worldcereal/openeo/inference.py
@@ -48,9 +48,12 @@ class CroplandClassifier(ModelInference):
         # Extract all prediction values and convert them to binary labels
         prediction_values = [sublist["True"] for sublist in outputs[1]]
         binary_labels = np.array(prediction_values) >= threshold
-        binary_labels = binary_labels.astype(int)
+        binary_labels = binary_labels.astype("uint8")
 
-        return np.stack([binary_labels, prediction_values], axis=0).astype(np.float32)
+        prediction_values = np.array(prediction_values) * 100.0
+        prediction_values = np.round(prediction_values).astype("uint8")
+
+        return np.stack([binary_labels, prediction_values], axis=0)
 
     def execute(self, inarr: xr.DataArray) -> xr.DataArray:
         classifier_url = self._parameters.get("classifier_url", self.CATBOOST_PATH)
@@ -62,9 +65,9 @@ class CroplandClassifier(ModelInference):
         self.onnx_session = self.load_ort_session(classifier_url)
 
         # Run catboost classification
-        self.logger.info(f"Catboost classification with input shape: {inarr.shape}")
+        self.logger.info("Catboost classification with input shape: %s", inarr.shape)
         classification = self.predict(inarr.values)
-        self.logger.info(f"Classification done with shape: {classification.shape}")
+        self.logger.info("Classification done with shape: %s", inarr.shape)
 
         classification = xr.DataArray(
             classification.reshape((2, len(x_coords), len(y_coords))),

--- a/src/worldcereal/openeo/inference.py
+++ b/src/worldcereal/openeo/inference.py
@@ -28,7 +28,7 @@ class CroplandClassifier(ModelInference):
         return []  # Disable the dependencies from PIP install
 
     def output_labels(self) -> list:
-        return ["classification"]
+        return ["classification", "probability"]
 
     def predict(self, features: np.ndarray) -> np.ndarray:
         """


### PR DESCRIPTION
Resolves #61 and #62 

Output GeoTiff example for parameters `664000 5611120 665000 5612120 2020-11-01 2021-10-31 --epsg 32631` can be found in my Public drive:
`/data/users/Public/couchard/gfmap_cropland_inference_probabilities.tif`

Output GeoTiff has two bands, the first one is the binary cropland mask and the second is the associated probabilities