### PR TITLE
Make version static for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ authors = [
 description = "WorldCereal classification module"
 readme = "README.md"
 requires-python = ">=3.8"
-dynamic = ["version"]
+# dynamic = ["version"]
+version = "2.0.2"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",


### PR DESCRIPTION
For now, Jenkins builds fail when we use dynamic versioning in TOML file. For the time being, we have to fix the version in the TOML file.