### PR TITLE
Added configuration data classes for cropland/croptype mapping workflow

### DIFF
--- a/scripts/inference/cropland_mapping.py
+++ b/scripts/inference/cropland_mapping.py
@@ -20,24 +20,24 @@ if __name__ == "__main__":
     parser.add_argument("maxx", type=float, help="Maximum X coordinate (east)")
     parser.add_argument("maxy", type=float, help="Maximum Y coordinate (north)")
     parser.add_argument(
-        "--epsg",
-        type=int,
-        default=4326,
-        help="EPSG code of the input `minx`, `miny`, `maxx`, `maxy` parameters.",
+        "start_date", type=str, help="Starting date for data extraction."
     )
+    parser.add_argument("end_date", type=str, help="Ending date for data extraction.")
     parser.add_argument(
         "product",
         type=str,
         help="Product to generate. One of ['cropland', 'croptype']",
     )
     parser.add_argument(
-        "start_date", type=str, help="Starting date for data extraction."
-    )
-    parser.add_argument("end_date", type=str, help="Ending date for data extraction.")
-    parser.add_argument(
         "output_path",
         type=Path,
         help="Path to folder where to save the resulting GeoTiff.",
+    )
+    parser.add_argument(
+        "--epsg",
+        type=int,
+        default=4326,
+        help="EPSG code of the input `minx`, `miny`, `maxx`, `maxy` parameters.",
     )
 
     args = parser.parse_args()

--- a/src/worldcereal/job.py
+++ b/src/worldcereal/job.py
@@ -1,6 +1,5 @@
 """Executing inference jobs on the OpenEO backend."""
 
-from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Union

--- a/src/worldcereal/openeo/mapping.py
+++ b/src/worldcereal/openeo/mapping.py
@@ -1,0 +1,129 @@
+"""Private methods for cropland/croptype mapping. The public functions that
+are interracting with the methods here are defined in the `worldcereal.job`
+sub-module.
+"""
+from typing import TYPE_CHECKING
+
+from openeo import DataCube
+from openeo_gfmap.features.feature_extractor import apply_feature_extractor
+from openeo_gfmap.inference.model_inference import apply_model_inference
+from openeo_gfmap.preprocessing.scaling import compress_uint8, compress_uint16
+
+if TYPE_CHECKING:  # To avoid cyclic imports during runtime
+    from worldcereal.job import CropLandParameters, CropTypeParameters
+
+
+def _cropland_map(
+    inputs: DataCube, cropland_parameters: "CropLandParameters"
+) -> DataCube:
+    """Method to produce cropland map from preprocessed inputs, using
+    a Presto feature extractor and a CatBoost classifier.
+
+    Parameters
+    ----------
+    inputs : DataCube
+        preprocessed input cube
+
+    Returns
+    -------
+    DataCube
+        binary labels and probability
+    """
+
+    # Run feature computer
+    features = apply_feature_extractor(
+        feature_extractor_class=cropland_parameters.feature_extractor,
+        cube=inputs,
+        parameters=cropland_parameters.features_parameters.dict(),
+        size=[
+            {"dimension": "x", "unit": "px", "value": 100},
+            {"dimension": "y", "unit": "px", "value": 100},
+        ],
+        overlap=[
+            {"dimension": "x", "unit": "px", "value": 0},
+            {"dimension": "y", "unit": "px", "value": 0},
+        ],
+    )
+
+    # Run model inference on features
+    classes = apply_model_inference(
+        model_inference_class=cropland_parameters.classifier,
+        cube=features,
+        parameters=cropland_parameters.classifier_parameters.dict(),
+        size=[
+            {"dimension": "x", "unit": "px", "value": 100},
+            {"dimension": "y", "unit": "px", "value": 100},
+            {"dimension": "t", "value": "P1D"},
+        ],
+        overlap=[
+            {"dimension": "x", "unit": "px", "value": 0},
+            {"dimension": "y", "unit": "px", "value": 0},
+        ],
+    )
+
+    # Cast to uint8
+    classes = compress_uint8(classes)
+
+    return classes
+
+
+def _croptype_map(
+    inputs: DataCube,
+    croptype_parameters: "CropTypeParameters",
+    cropland_mask: DataCube = None,
+) -> DataCube:
+    """Method to produce croptype map from preprocessed inputs, using
+    a Presto feature extractor and a CatBoost classifier.
+
+    Parameters
+    ----------
+    inputs : DataCube
+        preprocessed input cube
+    cropland_mask : DataCube, optional
+        optional cropland mask, by default None
+
+    Returns
+    -------
+    DataCube
+        croptype labels and probability
+    """
+
+    # Run feature computer
+    features = apply_feature_extractor(
+        feature_extractor_class=croptype_parameters.feature_extractor,
+        cube=inputs,
+        parameters=croptype_parameters.feature_parameters.dict(),
+        size=[
+            {"dimension": "x", "unit": "px", "value": 100},
+            {"dimension": "y", "unit": "px", "value": 100},
+        ],
+        overlap=[
+            {"dimension": "x", "unit": "px", "value": 0},
+            {"dimension": "y", "unit": "px", "value": 0},
+        ],
+    )
+
+    # Run model inference on features
+    classes = apply_model_inference(
+        model_inference_class=croptype_parameters.classifier,
+        cube=features,
+        parameters=croptype_parameters.classifier_parameters.dict(),
+        size=[
+            {"dimension": "x", "unit": "px", "value": 100},
+            {"dimension": "y", "unit": "px", "value": 100},
+            {"dimension": "t", "value": "P1D"},
+        ],
+        overlap=[
+            {"dimension": "x", "unit": "px", "value": 0},
+            {"dimension": "y", "unit": "px", "value": 0},
+        ],
+    )
+
+    # Mask cropland
+    if cropland_mask is not None:
+        classes = classes.mask(cropland_mask == 0, replacement=0)
+
+    # Cast to uint16
+    classes = compress_uint16(classes)
+
+    return classes


### PR DESCRIPTION
@kvantricht I added data classes for parameters that use `pydantic`, a very popular module to enforce the data types as described in the type hints (the module was already included in worldcereal, probably as a subdependency so it doesn't make our package more heavy).

One way of using them would be:
```python
from worldcereal.job import generate_map, WorldCerealProduct, CropTypeParameters

croptype_parameters = CropTypeParameters()
croptype_parameters.classifier_parameters.classifier_url = "https://s3.amazon.com/example/link.onnx"

inference_results = generate_map(
    spatial_extent=...,
    temporal_extent=...,
    backend_context=...,
    output_path=...,
    product_type=WorldCerealProduct.CROPTYPE,
    croptype_parameters=croptype_parameters,
)
```

I also changed the order of CLI parameters for the ´cropland_mapping.py` function, as I think it makes more sense to first define spatial/temporal context and after the product type and output file. `--epsg` is sent to the end (however it can be placed in any position by the user) as it is common practice.