### PR TITLE
fixed typo in the s1 item_asset definitions in extract_sar.py

### DIFF
--- a/scripts/extractions/patch_extractions/extract_sar.py
+++ b/scripts/extractions/patch_extractions/extract_sar.py
@@ -45,8 +45,8 @@ sentinel1_asset = pystac.extensions.item_assets.AssetDefinition(
             },
         ],
         "cube:variables": {
-            "S1-SIGMA0-VV": {"dimesions": ["time", "y", "x"], "type": "data"},
-            "S1-SIGMA0-VH": {"dimesions": ["time", "y", "x"], "type": "data"},
+            "S1-SIGMA0-VV": {"dimensions": ["time", "y", "x"], "type": "data"},
+            "S1-SIGMA0-VH": {"dimensions": ["time", "y", "x"], "type": "data"},
         },
         "eo:bands": [
             {


### PR DESCRIPTION
@GriffinBabe, just a small typo fix.

However, it's important to note that this typo makes it so that `load_stac` doesn't work. Luckily it's at collection level, so it can be easily adjusted for the extractions that are done already.