### PR TITLE
add slope band to post_job_action

### DIFF
--- a/scripts/extractions/point_extractions/extract_point_worldcereal.py
+++ b/scripts/extractions/point_extractions/extract_point_worldcereal.py
@@ -197,6 +197,7 @@ def post_job_action_point_worldcereal(
             "S1-SIGMA0-VH",
             "S1-SIGMA0-VV",
             "elevation",
+            "slope",
             "AGERA5-PRECIP",
             "AGERA5-TMEAN",
         ]


### PR DESCRIPTION
`slope` nowadays is in degrees and no longer in rise/run. Therefore it is compatible with dtype UINT16. It should be included in the post-job actions for casting to UINT16 and for setting NaN to 65535.