### PR TITLE
get_legend reads directly from URL + extended to IRR

### DIFF
--- a/scripts/misc/legend.py
+++ b/scripts/misc/legend.py
@@ -4,7 +4,12 @@ Example script showing how to upload, download and delete the WorldCereal crop t
 
 from pathlib import Path
 
-from worldcereal.utils.legend import delete_legend_file, get_legend, upload_legend
+from worldcereal.utils.legend import (
+    delete_legend_file,
+    download_legend,
+    get_legend,
+    upload_legend,
+)
 
 if __name__ == "__main__":
 
@@ -17,8 +22,17 @@ if __name__ == "__main__":
     # Upload the legend to Artifactory
     link = upload_legend(srcpath, date)
 
-    # Download the latest legend from Artifactory
+    # Get the latest legend from Artifactory (as pandas DataFrame)
     legend = get_legend()
+
+    legend_irr = get_legend(topic="irr")
+
+    # Download the latest legend from Artifactory
+    legend_path = download_legend(Path("/vitodata/worldcereal/tmp/jeroen/"))
+
+    irr_legend_path = download_legend(
+        Path("/vitodata/worldcereal/tmp/jeroen/"), topic="irr"
+    )
 
     # Delete the uploaded legend from Artifactory
     delete_legend_file(link)

--- a/scripts/misc/legend.py
+++ b/scripts/misc/legend.py
@@ -28,11 +28,9 @@ if __name__ == "__main__":
     legend_irr = get_legend(topic="irr")
 
     # Download the latest legend from Artifactory
-    legend_path = download_legend(Path("/vitodata/worldcereal/tmp/jeroen/"))
+    legend_path = download_legend(Path("."))
 
-    irr_legend_path = download_legend(
-        Path("/vitodata/worldcereal/tmp/jeroen/"), topic="irr"
-    )
+    irr_legend_path = download_legend(Path("."), topic="irr")
 
     # Delete the uploaded legend from Artifactory
     delete_legend_file(link)

--- a/scripts/misc/legend.py
+++ b/scripts/misc/legend.py
@@ -14,9 +14,7 @@ from worldcereal.utils.legend import (
 if __name__ == "__main__":
 
     # Example usage
-    srcpath = Path(
-        "/vitodata/worldcereal/data/legend/WorldCereal_LC_CT_legend_20241231.csv"
-    )
+    srcpath = Path("./WorldCereal_LC_CT_legend_20241231.csv")
     date = "20241231"
 
     # Upload the legend to Artifactory

--- a/scripts/misc/legend.py
+++ b/scripts/misc/legend.py
@@ -25,12 +25,12 @@ if __name__ == "__main__":
     # Get the latest legend from Artifactory (as pandas DataFrame)
     legend = get_legend()
 
-    legend_irr = get_legend(topic="irr")
+    legend_irr = get_legend(topic="irrigation")
 
     # Download the latest legend from Artifactory
     legend_path = download_legend(Path("."))
 
-    irr_legend_path = download_legend(Path("."), topic="irr")
+    irr_legend_path = download_legend(Path("."), topic="irrigation")
 
     # Delete the uploaded legend from Artifactory
     delete_legend_file(link)

--- a/src/worldcereal/utils/legend.py
+++ b/src/worldcereal/utils/legend.py
@@ -1,6 +1,7 @@
 import os
 import time
 from pathlib import Path
+from typing import Literal
 
 import pandas as pd
 import requests
@@ -155,15 +156,15 @@ def upload_legend(srcpath: Path, date: str) -> str:
     return artifactory_link
 
 
-def get_legend(topic: str = "crop") -> pd.DataFrame:
+def get_legend(topic: Literal["landcover", "irrigation"] = "landcover") -> pd.DataFrame:
     """Get the latest version of the WorldCereal land cover/crop type or irrigation legend
     from artifactory.
 
     Parameters
     ----------
-    topic : str
+    topic : Literal['landcover', 'irrigation'], optional
         Specifier for the legend file to be downloaded.
-        Options are 'crop' for land cover/crop type legend and 'irr' for irrigation legend.
+        Options are 'landcover' for land cover/crop type legend and 'irrigation' for irrigation legend.
 
     Returns
     -------
@@ -176,27 +177,32 @@ def get_legend(topic: str = "crop") -> pd.DataFrame:
         if topic got an invalid value
     """
 
-    if topic == "crop":
+    if topic == "landcover":
         url = CROP_LEGEND_URL
-    elif topic == "irr":
+    elif topic == "irrigation":
         url = IRR_LEGEND_URL
     else:
-        raise ValueError("Invalid topic. Please use 'crop' or 'irr'.")
+        raise ValueError("Invalid topic. Please use 'landcover' or 'irrigation'.")
 
     legend = pd.read_csv(url, header=0, sep=";")
 
     return legend
 
 
-def download_legend(dstpath: Path, topic: str = "crop", retries=3, wait=2) -> Path:
+def download_legend(
+    dstpath: Path,
+    topic: Literal["landcover", "irrigation"] = "landcover",
+    retries=3,
+    wait=2,
+) -> Path:
     """Download the latest version of the WorldCereal legend from Artifactory.
     Parameters
     ----------
     dstpath : Path
         Folder where the legend needs to be downloaded to.
-    topic : str
+    topic : Literal['landcover', 'irrigation'], optional
         Specifier for the legend file to be downloaded.
-        Options are 'crop' for land cover/crop type legend and 'irr' for irrigation legend.
+        Options are 'landcover' for land cover/crop type legend and 'irrigation' for irrigation legend.
     retries : int, optional
         Number of retries, by default 3
     wait : int, optional
@@ -213,12 +219,12 @@ def download_legend(dstpath: Path, topic: str = "crop", retries=3, wait=2) -> Pa
         if topic got an invalid value
     """
     # Construct the download link
-    if topic == "crop":
+    if topic == "landcover":
         url = CROP_LEGEND_URL
-    elif topic == "irr":
+    elif topic == "irrigation":
         url = IRR_LEGEND_URL
     else:
-        raise ValueError("Invalid topic. Please use 'crop' or 'irr'.")
+        raise ValueError("Invalid topic. Please use 'landcover' or 'irrigation'.")
 
     # Construct target path
     dstpath.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Based on suggestion from @cbutsko, get_legend now reads the legend directly from the URL instead of first downloading it.
I kept the function download_legend as well just in case some applications would require downloading the actual file...

I also added support to download the irrigation legend. 
get_legend by default returns the crop type legend, but you can get the irrigation legend by specifying the "topic"