### PR TITLE
Update patch post job actions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -35,7 +35,7 @@ dependencies:
   - pip:
     - duckdb==1.1.0
     - h3==4.1.0
-    - openeo-gfmap==0.3.0
+    - openeo-gfmap==0.4.0
     - git+https://github.com/worldcereal/worldcereal-classification
     - git+https://github.com/WorldCereal/presto-worldcereal.git@croptype
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "netcdf4<=1.6.4",  
     "numpy<2.0.0",  
     "openeo==0.31.0",  
-    "openeo-gfmap==0.3.0",  
+    "openeo-gfmap==0.4.0",  
     "pyarrow",  
     "pydantic==2.8.0",  
     "rioxarray>=0.13.0",  

--- a/scripts/extractions/extract.py
+++ b/scripts/extractions/extract.py
@@ -147,6 +147,7 @@ def setup_extraction_functions(
     memory: typing.Union[str, None],
     python_memory: typing.Union[str, None],
     max_executors: typing.Union[int, None],
+    write_stac_api: bool,
 ) -> tuple[typing.Callable, typing.Callable, typing.Callable]:
     """Setup the datacube creation, path generation and post-job action
     functions for the given collection. Returns a tuple of three functions:
@@ -229,7 +230,7 @@ def setup_extraction_functions(
             spatial_resolution="20m",
             s1_orbit_fix=True,
             sensor="Sentinel1",
-            write_stac_api=True,
+            write_stac_api=write_stac_api,
         ),
         ExtractionCollection.PATCH_SENTINEL2: partial(
             post_job_action_patch,
@@ -238,7 +239,7 @@ def setup_extraction_functions(
             title="Sentinel-2 L2A",
             spatial_resolution="10m",
             sensor="Sentinel2",
-            write_stac_api=True,
+            write_stac_api=write_stac_api,
         ),
         ExtractionCollection.PATCH_METEO: partial(
             post_job_action_patch,
@@ -346,6 +347,7 @@ def run_extractions(
     restart_failed: bool = False,
     extract_value: int = 1,
     backend=Backend.CDSE,
+    write_stac_api: bool = True,
 ) -> None:
     """Main function responsible for launching point and patch extractions.
 
@@ -399,7 +401,7 @@ def run_extractions(
     # Setup the extraction functions
     pipeline_log.info("Setting up the extraction functions.")
     datacube_fn, path_fn, post_job_fn = setup_extraction_functions(
-        collection, extract_value, memory, python_memory, max_executors
+        collection, extract_value, memory, python_memory, max_executors, write_stac_api
     )
 
     # Initialize and setups the job manager
@@ -482,6 +484,12 @@ if __name__ == "__main__":
         default=1,
         help="The value of the `extract` flag to use in the dataframe.",
     )
+    parser.add_argument(
+        "--write_stac_api",
+        type=bool,
+        default=True,
+        help="Flag to write S1 and S2 patch extraction results to STAC API or not.",
+    )
 
     args = parser.parse_args()
 
@@ -497,4 +505,5 @@ if __name__ == "__main__":
         restart_failed=args.restart_failed,
         extract_value=args.extract_value,
         backend=Backend.CDSE,
+        write_stac_api=args.write_stac_api,
     )

--- a/scripts/extractions/extract.py
+++ b/scripts/extractions/extract.py
@@ -225,7 +225,7 @@ def setup_extraction_functions(
         ExtractionCollection.PATCH_SENTINEL1: partial(
             post_job_action_patch,
             extract_value=extract_value,
-            description="Sentinel1 GRD raw observations, unprocessed.",
+            description="Sentinel-1 GRD backscatter observations, processed with Orfeo toolbox.",
             title="Sentinel-1 GRD",
             spatial_resolution="20m",
             s1_orbit_fix=True,

--- a/src/worldcereal/extract/common.py
+++ b/src/worldcereal/extract/common.py
@@ -110,7 +110,7 @@ def post_job_action_patch(
             "start_date": row.start_date,
             "end_date": row.end_date,
             "valid_time": valid_time,
-            "GFMAP_version": version("openeo_gfmap"),
+            "processing:version": version("openeo_gfmap"),
             "creation_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             "description": description,
             "title": title,
@@ -123,7 +123,7 @@ def post_job_action_patch(
         }
 
         if s1_orbit_fix:
-            new_attributes["orbit_state"] = row.orbit_state
+            new_attributes["sat:orbit_state"] = row.orbit_state
             item.id = item.id.replace(".nc", f"_{row.orbit_state}.nc")
 
         # Saves the new attributes in the netcdf file

--- a/src/worldcereal/extract/common.py
+++ b/src/worldcereal/extract/common.py
@@ -195,13 +195,12 @@ def generate_output_path_patch(
 
     s2_tile_id = row.s2_tile
     utm_zone = str(s2_tile_id[0:2])
-    epsg = s2_grid[s2_grid.tile == s2_tile_id].iloc[0].epsg
 
     subfolder = root_folder / ref_id / utm_zone / s2_tile_id / sample_id
 
     return (
         subfolder
-        / f"{row.out_prefix}{orbit_state}_{sample_id}_{epsg}_{row.start_date}_{row.end_date}{row.out_extension}"
+        / f"{row.out_prefix}{orbit_state}_{sample_id}_{row.start_date}_{row.end_date}{row.out_extension}"
     )
 
 

--- a/src/worldcereal/extract/common.py
+++ b/src/worldcereal/extract/common.py
@@ -111,6 +111,7 @@ def post_job_action_patch(
             "end_date": row.end_date,
             "valid_time": valid_time,
             "processing:version": version("openeo_gfmap"),
+            "institution": "VITO - ESA WorldCereal",
             "creation_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             "description": description,
             "title": title,
@@ -134,6 +135,18 @@ def post_job_action_patch(
         with NamedTemporaryFile(delete=False) as temp_file:
             ds.to_netcdf(temp_file.name)
             shutil.move(temp_file.name, item_asset_path)
+
+        # Update the metadata of the item
+        if write_stac_api:
+            item.properties.update(new_attributes)
+
+            providers = [{"name": "openEO platform"}]
+            item.properties["providers"] = providers
+
+            extension = (
+                "https://stac-extensions.github.io/processing/v1.2.0/schema.json"
+            )
+            item.stac_extensions.extend([extension])
 
     if write_stac_api:
         username = os.getenv("STAC_API_USERNAME")

--- a/src/worldcereal/stac/stac_api_interaction.py
+++ b/src/worldcereal/stac/stac_api_interaction.py
@@ -67,7 +67,9 @@ class StacApiInteraction:
             )
         self.sensor = sensor
         self.base_url = base_url
-        self.collection_id = f"worldcereal_{sensor[:-1].lower()}_{sensor[-1]}_patch_extractions"
+        self.collection_id = (
+            f"worldcereal_{sensor[:-1].lower()}_{sensor[-1]}_patch_extractions"
+        )
 
         self.auth = auth
 

--- a/src/worldcereal/stac/stac_api_interaction.py
+++ b/src/worldcereal/stac/stac_api_interaction.py
@@ -67,7 +67,7 @@ class StacApiInteraction:
             )
         self.sensor = sensor
         self.base_url = base_url
-        self.collection_id = f"worldcereal_{sensor.lower()}_patch_extractions"
+        self.collection_id = f"worldcereal_{sensor[:-1].lower()}_{sensor[-1]}_patch_extractions"
 
         self.auth = auth
 

--- a/src/worldcereal/stac/stac_api_interaction.py
+++ b/src/worldcereal/stac/stac_api_interaction.py
@@ -58,22 +58,29 @@ class VitoStacApiAuthentication(AuthBase):
 class StacApiInteraction:
     """Class that handles the interaction with a STAC API."""
 
+    _SENSOR_COLLECTION_CATALOG = {
+        "Sentinel1": "worldcereal_sentinel_1_patch_extractions",
+        "Sentinel2": "worldcereal_sentinel_2_patch_extractions",
+    }
+
     def __init__(
         self, sensor: str, base_url: str, auth: AuthBase, bulk_size: int = 500
     ):
-        if sensor not in ["Sentinel1", "Sentinel2"]:
+        if sensor not in self.catalog.keys():
             raise ValueError(
-                f"Invalid sensor '{sensor}'. Allowed values are 'Sentinel1' and 'Sentinel2'."
+                f"Invalid sensor '{sensor}'. Allowed values are: {', '.join(self.catalog.keys())}."
             )
         self.sensor = sensor
         self.base_url = base_url
-        self.collection_id = (
-            f"worldcereal_{sensor[:-1].lower()}_{sensor[-1]}_patch_extractions"
-        )
+        self.collection_id = self.catalog[self.sensor]
 
         self.auth = auth
 
         self.bulk_size = bulk_size
+
+    @property
+    def catalog(self):
+        return self._SENSOR_COLLECTION_CATALOG.copy()
 
     def exists(self) -> bool:
         client = pystac_client.Client.open(self.base_url)


### PR DESCRIPTION
Post job actions for patch extractions have been updated so that:

- The resulting STAC items now contain the same metadata in their properties as the underlying netCDFs in their attributes
- The S2 tile is assigned based on the latest version of GFMap
- As much as possible metadata follows the schema of existing STAC extensions
- Users can now disable `write_stac_api` for S1 and S2 patch extractions; useful in testing

Note that:
- `epsg` had to be removed from `generate_output_path_patch`, since - with the new version of `split_job_s2grid` - there is no way to find out the EPSG code, without accessing the STAC metadata. This STAC metadata is not accessed by `generate_output_path_patch`, so would require a rewriting of the `GFMapJobManager`

The extractions have been run on a test dataset and were successfully loaded back in openEO using `load_stac`.