### PR TITLE
move extraction functions scripts > src

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -35,7 +35,7 @@ dependencies:
   - pip:
     - duckdb==1.1.3
     - h3==4.1.0
-    - openeo-gfmap==0.4.0
+    - openeo-gfmap==0.4.2
     - git+https://github.com/worldcereal/worldcereal-classification
     - git+https://github.com/WorldCereal/presto-worldcereal.git@croptype
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "netcdf4<=1.6.4",  
     "numpy<2.0.0",  
     "openeo==0.31.0",  
-    "openeo-gfmap==0.4.0",  
+    "openeo-gfmap==0.4.2",  
     "pyarrow",  
     "pydantic==2.8.0",  
     "rioxarray>=0.13.0",  

--- a/scripts/extractions/extract.py
+++ b/scripts/extractions/extract.py
@@ -167,13 +167,13 @@ def run_extractions(
     """
 
     # Compile custom job options
-    custom_job_options: Dict[str, Union[str, int]] = {}
+    job_options: Dict[str, Union[str, int]] = {}
     if memory:
-        custom_job_options["memory"] = memory
+        job_options["memory"] = memory
     if python_memory:
-        custom_job_options["python_memory"] = python_memory
+        job_options["python_memory"] = python_memory
     if max_executors:
-        custom_job_options["max_executors"] = max_executors
+        job_options["max_executors"] = max_executors
 
     # Prepare extraction jobs
     job_manager, job_df, datacube_fn, tracking_df_path = prepare_extraction_jobs(
@@ -181,7 +181,7 @@ def run_extractions(
         output_folder,
         samples_df_path,
         max_locations_per_job=max_locations_per_job,
-        custom_job_options=custom_job_options,
+        job_options=job_options,
         parallel_jobs=parallel_jobs,
         restart_failed=restart_failed,
         extract_value=extract_value,

--- a/scripts/extractions/extract.py
+++ b/scripts/extractions/extract.py
@@ -127,7 +127,7 @@ def run_extractions(
     restart_failed: bool = False,
     extract_value: int = 1,
     backend=Backend.CDSE,
-    write_stac_api: bool = True,
+    write_stac_api: bool = False,
 ) -> None:
     """Main function responsible for launching point and patch extractions.
 
@@ -260,7 +260,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--write_stac_api",
         type=bool,
-        default=True,
+        default=False,
         help="Flag to write S1 and S2 patch extraction results to STAC API or not.",
     )
 

--- a/scripts/extractions/extract.py
+++ b/scripts/extractions/extract.py
@@ -15,9 +15,9 @@ from openeo_gfmap import Backend
 from openeo_gfmap.manager.job_manager import GFMAPJobManager
 
 from worldcereal.extract.common import (
-    merge_extraction_jobs,
+    _merge_extraction_jobs,
+    _prepare_extraction_jobs,
     pipeline_log,
-    prepare_extraction_jobs,
 )
 from worldcereal.stac.constants import ExtractionCollection
 
@@ -176,7 +176,7 @@ def run_extractions(
         job_options["max_executors"] = max_executors
 
     # Prepare extraction jobs
-    job_manager, job_df, datacube_fn, tracking_df_path = prepare_extraction_jobs(
+    job_manager, job_df, datacube_fn, tracking_df_path = _prepare_extraction_jobs(
         collection,
         output_folder,
         samples_df_path,
@@ -195,7 +195,7 @@ def run_extractions(
     pipeline_log.info("Extraction completed successfully.")
 
     # Merge the extractions (for point jobs only)
-    merge_extraction_jobs(collection, output_folder, samples_df_path)
+    _merge_extraction_jobs(collection, output_folder, samples_df_path)
 
     send_notification(
         title=f"WorldCereal Extraction {collection.value} - Completed",

--- a/scripts/extractions/extract.py
+++ b/scripts/extractions/extract.py
@@ -3,55 +3,23 @@ own functions, but the setup and main thread execution is done here."""
 
 import argparse
 import os
-import typing
 from datetime import datetime
-from functools import partial
 from pathlib import Path
+from typing import Callable, Dict, Optional, Union
 
 import geopandas as gpd
 import pandas as pd
 import requests
 from openeo.rest import OpenEoApiError, OpenEoApiPlainError, OpenEoRestError
 from openeo_gfmap import Backend
-from openeo_gfmap.backend import cdse_connection
 from openeo_gfmap.manager.job_manager import GFMAPJobManager
-from openeo_gfmap.manager.job_splitters import load_s2_grid, split_job_s2grid
 
 from worldcereal.extract.common import (
-    generate_output_path_patch,
+    merge_extraction_jobs,
     pipeline_log,
-    post_job_action_patch,
-)
-from worldcereal.extract.patch_meteo import (
-    create_job_dataframe_patch_meteo,
-    create_job_patch_meteo,
-)
-from worldcereal.extract.patch_s2 import (
-    create_job_dataframe_patch_s2,
-    create_job_patch_s2,
-)
-from worldcereal.extract.point_worldcereal import (
-    create_job_dataframe_point_worldcereal,
-    create_job_point_worldcereal,
-    generate_output_path_point_worldcereal,
-    merge_output_files_point_worldcereal,
-    post_job_action_point_worldcereal,
+    prepare_extraction_jobs,
 )
 from worldcereal.stac.constants import ExtractionCollection
-
-from worldcereal.extract.patch_s1 import (  # isort: skip
-    create_job_patch_s1,
-    create_job_dataframe_patch_s1,
-)
-
-
-from worldcereal.extract.patch_worldcereal import (  # isort: skip
-    create_job_patch_worldcereal,
-    create_job_dataframe_patch_worldcereal,
-    post_job_action_patch_worldcereal,
-    generate_output_path_patch_worldcereal,
-)
-
 
 # Pushover API endpoint, allowing to send notifications to personal devices.
 PUSHOVER_API_ENDPOINT = "https://api.pushover.net/1/messages.json"
@@ -82,200 +50,11 @@ def send_notification(message: str, title: str = "OpenEO-GFMAP") -> None:
         pipeline_log.error("Error sending the notification: %s", response.text)
 
 
-def load_dataframe(df_path: Path) -> gpd.GeoDataFrame:
-    """Load the input dataframe from the given path."""
-    pipeline_log.info("Loading input dataframe from %s.", df_path)
-
-    if df_path.name.endswith(".geoparquet"):
-        return gpd.read_parquet(df_path)
-    else:
-        return gpd.read_file(df_path)
-
-
-def prepare_job_dataframe(
-    input_df: gpd.GeoDataFrame,
-    collection: ExtractionCollection,
-    max_locations: int,
-    extract_value: int,
-    backend: Backend,
-) -> gpd.GeoDataFrame:
-    """Prepare the job dataframe to extract the data from the given input
-    dataframe."""
-    pipeline_log.info("Preparing the job dataframe.")
-
-    # Filter the input dataframe to only keep the locations to extract
-    input_df = input_df[input_df["extract"] >= extract_value].copy()
-
-    # Split the locations into chunks of max_locations
-    split_dfs = []
-    pipeline_log.info(
-        "Performing splitting by the year...",
-    )
-    input_df["valid_time"] = pd.to_datetime(input_df.valid_time)
-    input_df["year"] = input_df.valid_time.dt.year
-
-    split_dfs_time = [group.reset_index() for _, group in input_df.groupby("year")]
-    pipeline_log.info("Performing splitting by s2 grid...")
-    for df in split_dfs_time:
-        s2_split_df = split_job_s2grid(df, max_points=max_locations)
-        split_dfs.extend(s2_split_df)
-
-    pipeline_log.info("Dataframes split to jobs, creating the job dataframe...")
-    collection_switch: dict[ExtractionCollection, typing.Callable] = {
-        ExtractionCollection.PATCH_SENTINEL1: create_job_dataframe_patch_s1,
-        ExtractionCollection.PATCH_SENTINEL2: create_job_dataframe_patch_s2,
-        ExtractionCollection.PATCH_METEO: create_job_dataframe_patch_meteo,
-        ExtractionCollection.PATCH_WORLDCEREAL: create_job_dataframe_patch_worldcereal,
-        ExtractionCollection.POINT_WORLDCEREAL: create_job_dataframe_point_worldcereal,
-    }
-
-    create_job_dataframe_fn = collection_switch.get(
-        collection,
-        lambda: (_ for _ in ()).throw(
-            ValueError(f"Collection {collection} not supported.")
-        ),
-    )
-
-    job_df = create_job_dataframe_fn(backend, split_dfs)
-    pipeline_log.info("Job dataframe created with %s jobs.", len(job_df))
-
-    return job_df
-
-
-def setup_extraction_functions(
-    collection: ExtractionCollection,
-    extract_value: int,
-    memory: typing.Union[str, None],
-    python_memory: typing.Union[str, None],
-    max_executors: typing.Union[int, None],
-    write_stac_api: bool,
-) -> tuple[typing.Callable, typing.Callable, typing.Callable]:
-    """Setup the datacube creation, path generation and post-job action
-    functions for the given collection. Returns a tuple of three functions:
-    1. The datacube creation function
-    2. The output path generation function
-    3. The post-job action function
-    """
-
-    datacube_creation = {
-        ExtractionCollection.PATCH_SENTINEL1: partial(
-            create_job_patch_s1,
-            executor_memory=memory if memory is not None else "1800m",
-            python_memory=python_memory if python_memory is not None else "1900m",
-            max_executors=max_executors if max_executors is not None else 22,
-        ),
-        ExtractionCollection.PATCH_SENTINEL2: partial(
-            create_job_patch_s2,
-            executor_memory=memory if memory is not None else "1800m",
-            python_memory=python_memory if python_memory is not None else "1900m",
-            max_executors=max_executors if max_executors is not None else 22,
-        ),
-        ExtractionCollection.PATCH_METEO: partial(
-            create_job_patch_meteo,
-            executor_memory=memory if memory is not None else "1800m",
-            python_memory=python_memory if python_memory is not None else "1000m",
-            max_executors=max_executors if max_executors is not None else 22,
-        ),
-        ExtractionCollection.PATCH_WORLDCEREAL: partial(
-            create_job_patch_worldcereal,
-            executor_memory=memory if memory is not None else "1800m",
-            python_memory=python_memory if python_memory is not None else "3000m",
-            max_executors=max_executors if max_executors is not None else 22,
-        ),
-        ExtractionCollection.POINT_WORLDCEREAL: partial(
-            create_job_point_worldcereal,
-            executor_memory=memory if memory is not None else "1800m",
-            python_memory=python_memory if python_memory is not None else "3000m",
-            max_executors=max_executors if max_executors is not None else 22,
-        ),
-    }
-
-    datacube_fn = datacube_creation.get(
-        collection,
-        lambda: (_ for _ in ()).throw(
-            ValueError(f"Collection {collection} not supported.")
-        ),
-    )
-
-    path_fns = {
-        ExtractionCollection.PATCH_SENTINEL1: partial(
-            generate_output_path_patch, s2_grid=load_s2_grid()
-        ),
-        ExtractionCollection.PATCH_SENTINEL2: partial(
-            generate_output_path_patch, s2_grid=load_s2_grid()
-        ),
-        ExtractionCollection.PATCH_METEO: partial(
-            generate_output_path_patch, s2_grid=load_s2_grid()
-        ),
-        ExtractionCollection.PATCH_WORLDCEREAL: partial(
-            generate_output_path_patch_worldcereal, s2_grid=load_s2_grid()
-        ),
-        ExtractionCollection.POINT_WORLDCEREAL: partial(
-            generate_output_path_point_worldcereal
-        ),
-    }
-
-    path_fn = path_fns.get(
-        collection,
-        lambda: (_ for _ in ()).throw(
-            ValueError(f"Collection {collection} not supported.")
-        ),
-    )
-
-    post_job_actions = {
-        ExtractionCollection.PATCH_SENTINEL1: partial(
-            post_job_action_patch,
-            extract_value=extract_value,
-            description="Sentinel-1 GRD backscatter observations, processed with Orfeo toolbox.",
-            title="Sentinel-1 GRD",
-            spatial_resolution="20m",
-            s1_orbit_fix=True,
-            sensor="Sentinel1",
-            write_stac_api=write_stac_api,
-        ),
-        ExtractionCollection.PATCH_SENTINEL2: partial(
-            post_job_action_patch,
-            extract_value=extract_value,
-            description="Sentinel2 L2A observations, processed.",
-            title="Sentinel-2 L2A",
-            spatial_resolution="10m",
-            sensor="Sentinel2",
-            write_stac_api=write_stac_api,
-        ),
-        ExtractionCollection.PATCH_METEO: partial(
-            post_job_action_patch,
-            extract_value=extract_value,
-            description="Meteo observations",
-            title="Meteo observations",
-            spatial_resolution="1deg",
-        ),
-        ExtractionCollection.PATCH_WORLDCEREAL: partial(
-            post_job_action_patch_worldcereal,
-            extract_value=extract_value,
-            description="WorldCereal preprocessed inputs",
-            title="WorldCereal inputs",
-            spatial_resolution="10m",
-        ),
-        ExtractionCollection.POINT_WORLDCEREAL: partial(
-            post_job_action_point_worldcereal,
-        ),
-    }
-
-    post_job_fn = post_job_actions.get(
-        collection,
-        lambda: (_ for _ in ()).throw(
-            ValueError(f"Collection {collection} not supported.")
-        ),
-    )
-
-    return datacube_fn, path_fn, post_job_fn
-
-
 def manager_main_loop(
     manager: GFMAPJobManager,
     collection: ExtractionCollection,
     job_df: gpd.GeoDataFrame,
-    datacube_fn: typing.Callable,
+    datacube_fn: Callable,
     tracking_df_path: Path,
 ) -> None:
     """Main loop for the job manager, re-running it whenever an uncatched
@@ -339,11 +118,11 @@ def manager_main_loop(
 def run_extractions(
     collection: ExtractionCollection,
     output_folder: Path,
-    input_df: Path,
+    samples_df_path: Path,
     max_locations_per_job: int = 500,
-    memory: str = "1800m",
-    python_memory: str = "1900m",
-    max_executors: int = 22,
+    memory: Optional[str] = None,
+    python_memory: Optional[str] = None,
+    max_executors: Optional[int] = None,
     parallel_jobs: int = 2,
     restart_failed: bool = False,
     extract_value: int = 1,
@@ -358,18 +137,20 @@ def run_extractions(
         The collection to extract. Most popular: PATCH_WORLDCEREAL, POINT_WORLDCEREAL
     output_folder : Path
         The folder where to store the extracted data
-    input_df : Path
+    samples_df_path : Path
         Path to the input dataframe containing the geometries
         for which extractions need to be done
     max_locations_per_job : int, optional
         The maximum number of locations to extract per job, by default 500
     memory : str, optional
-        Memory to allocate for the executor, by default "1800m"
+        Memory to allocate for the executor.
+        If not specified, the default value is used, depending on type of collection.
     python_memory : str, optional
         Memory to allocate for the python processes as well as OrfeoToolbox in the executors,
-        by default "1900m"
+        If not specified, the default value is used, depending on type of collection.
     max_executors : int, optional
-        Number of executors to run, by default 22
+        Number of executors to run.
+        If not specified, the default value is used, depending on type of collection.
     parallel_jobs : int, optional
         The maximum number of parallel jobs to run at the same time, by default 10
     restart_failed : bool, optional
@@ -385,54 +166,36 @@ def run_extractions(
         _description_
     """
 
-    if not output_folder.is_dir():
-        output_folder.mkdir(parents=True)
+    # Compile custom job options
+    custom_job_options: Dict[str, Union[str, int]] = {}
+    if memory:
+        custom_job_options["memory"] = memory
+    if python_memory:
+        custom_job_options["python_memory"] = python_memory
+    if max_executors:
+        custom_job_options["max_executors"] = max_executors
 
-    tracking_df_path = output_folder / "job_tracking.csv"
-
-    # Load the input dataframe and build the job dataframe
-    input_gdf = load_dataframe(input_df)
-
-    job_df = None
-    if not tracking_df_path.exists():
-        job_df = prepare_job_dataframe(
-            input_gdf, collection, max_locations_per_job, extract_value, backend
-        )
-
-    # Setup the extraction functions
-    pipeline_log.info("Setting up the extraction functions.")
-    datacube_fn, path_fn, post_job_fn = setup_extraction_functions(
-        collection, extract_value, memory, python_memory, max_executors, write_stac_api
-    )
-
-    # Initialize and setups the job manager
-    pipeline_log.info("Initializing the job manager.")
-
-    job_manager = GFMAPJobManager(
-        output_dir=output_folder,
-        output_path_generator=path_fn,
-        post_job_action=post_job_fn,
-        poll_sleep=60,
-        n_threads=4,
-        restart_failed=restart_failed,
-        stac_enabled=False,
-    )
-
-    job_manager.add_backend(
-        backend.value,
-        cdse_connection,
+    # Prepare extraction jobs
+    job_manager, job_df, datacube_fn, tracking_df_path = prepare_extraction_jobs(
+        collection,
+        output_folder,
+        samples_df_path,
+        max_locations_per_job=max_locations_per_job,
+        custom_job_options=custom_job_options,
         parallel_jobs=parallel_jobs,
+        restart_failed=restart_failed,
+        extract_value=extract_value,
+        backend=backend,
+        write_stac_api=write_stac_api,
     )
 
+    # Run the extraction jobs with push notifications
     manager_main_loop(job_manager, collection, job_df, datacube_fn, tracking_df_path)
 
     pipeline_log.info("Extraction completed successfully.")
 
-    if collection == ExtractionCollection.POINT_WORLDCEREAL:
-        pipeline_log.info("Merging Geoparquet results...")
-        ref_id = Path(input_df).stem
-        merge_output_files_point_worldcereal(output_folder=output_folder, ref_id=ref_id)
-        pipeline_log.info("Geoparquet results merged successfully.")
+    # Merge the extractions (for point jobs only)
+    merge_extraction_jobs(collection, output_folder, samples_df_path)
 
     send_notification(
         title=f"WorldCereal Extraction {collection.value} - Completed",
@@ -452,7 +215,9 @@ if __name__ == "__main__":
         "output_folder", type=Path, help="The folder where to store the extracted data"
     )
     parser.add_argument(
-        "input_df", type=Path, help="The input dataframe with the data to extract"
+        "samples_df_path",
+        type=Path,
+        help="Path to the samples dataframe with the data to extract",
     )
     parser.add_argument(
         "--max_locations",
@@ -504,7 +269,7 @@ if __name__ == "__main__":
     run_extractions(
         collection=args.collection,
         output_folder=args.output_folder,
-        input_df=args.input_df,
+        samples_df_path=args.samples_df_path,
         max_locations_per_job=args.max_locations,
         memory=args.memory,
         python_memory=args.python_memory,

--- a/src/worldcereal/extract/common.py
+++ b/src/worldcereal/extract/common.py
@@ -56,9 +56,9 @@ from worldcereal.extract.patch_worldcereal import (  # isort: skip
 )
 
 
-RETRIES = int(os.environ.get("WORLDCEREAL_RETRIES", 3))
-DELAY = int(os.environ.get("WORLDCEREAL_DELAY", 5))
-BACKOFF = int(os.environ.get("WORLDCEREAL_BACKOFF", 1))
+RETRIES = int(os.environ.get("WORLDCEREAL_EXTRACTION_RETRIES", 5))
+DELAY = int(os.environ.get("WORLDCEREAL_EXTRACTION_DELAY", 10))
+BACKOFF = int(os.environ.get("WORLDCEREAL_EXTRACTION_BACKOFF", 5))
 
 
 def post_job_action_patch(

--- a/src/worldcereal/extract/common.py
+++ b/src/worldcereal/extract/common.py
@@ -388,7 +388,7 @@ def prepare_extraction_jobs(
     restart_failed: bool = False,
     extract_value: int = 1,
     backend=Backend.CDSE,
-    write_stac_api: bool = True,
+    write_stac_api: bool = False,
 ) -> tuple[GFMAPJobManager, pd.DataFrame, Callable, Path]:
 
     # Make sure output folder exists
@@ -476,7 +476,7 @@ def run_extractions(
     restart_failed: bool = False,
     extract_value: int = 1,
     backend=Backend.CDSE,
-    write_stac_api: bool = True,
+    write_stac_api: bool = False,
 ) -> Path:
     """Main function responsible for launching point and patch extractions.
 

--- a/src/worldcereal/extract/common.py
+++ b/src/worldcereal/extract/common.py
@@ -500,6 +500,7 @@ def _run_extraction_jobs(
     # Run the extraction jobs
     pipeline_log.info("Running the extraction jobs.")
     job_manager.run_jobs(job_df, datacube_fn, tracking_df_path)
+    pipeline_log.info("Extraction jobs completed.")
     return
 
 
@@ -571,6 +572,7 @@ def run_extractions(
     Path
         Path to the job tracking dataframe
     """
+    pipeline_log.info("Starting the extractions workflow...")
 
     # Prepare the extraction jobs
     job_manager, job_df, datacube_fn, tracking_df_path = _prepare_extraction_jobs(
@@ -591,5 +593,7 @@ def run_extractions(
 
     # Merge the extraction jobs (for point extractions)
     _merge_extraction_jobs(collection, output_folder, samples_df_path)
+
+    pipeline_log.info("Extractions workflow completed.")
 
     return tracking_df_path

--- a/src/worldcereal/extract/common.py
+++ b/src/worldcereal/extract/common.py
@@ -276,7 +276,7 @@ def setup_extraction_functions(
     collection: ExtractionCollection,
     extract_value: int,
     write_stac_api: bool,
-    custom_job_options: Optional[dict] = None,
+    job_options: Optional[dict] = None,
 ) -> tuple[Callable, Callable, Callable]:
     """Setup the datacube creation, path generation and post-job action
     functions for the given collection. Returns a tuple of three functions:
@@ -288,19 +288,19 @@ def setup_extraction_functions(
     # Setup the datacube creation function
     datacube_creation = {
         ExtractionCollection.PATCH_SENTINEL1: partial(
-            create_job_patch_s1, custom_job_options=custom_job_options
+            create_job_patch_s1, job_options=job_options
         ),
         ExtractionCollection.PATCH_SENTINEL2: partial(
-            create_job_patch_s2, custom_job_options=custom_job_options
+            create_job_patch_s2, job_options=job_options
         ),
         ExtractionCollection.PATCH_METEO: partial(
-            create_job_patch_meteo, custom_job_options=custom_job_options
+            create_job_patch_meteo, job_options=job_options
         ),
         ExtractionCollection.PATCH_WORLDCEREAL: partial(
-            create_job_patch_worldcereal, custom_job_options=custom_job_options
+            create_job_patch_worldcereal, job_options=job_options
         ),
         ExtractionCollection.POINT_WORLDCEREAL: partial(
-            create_job_point_worldcereal, custom_job_options=custom_job_options
+            create_job_point_worldcereal, job_options=job_options
         ),
     }
 
@@ -383,7 +383,7 @@ def prepare_extraction_jobs(
     output_folder: Path,
     samples_df_path: Path,
     max_locations_per_job: int = 500,
-    custom_job_options: Optional[Dict[str, Union[str, int]]] = None,
+    job_options: Optional[Dict[str, Union[str, int]]] = None,
     parallel_jobs: int = 2,
     restart_failed: bool = False,
     extract_value: int = 1,
@@ -410,7 +410,7 @@ def prepare_extraction_jobs(
     # Setup the extraction functions
     pipeline_log.info("Setting up the extraction functions.")
     datacube_fn, path_fn, post_job_fn = setup_extraction_functions(
-        collection, extract_value, write_stac_api, custom_job_options
+        collection, extract_value, write_stac_api, job_options
     )
 
     # Initialize and setups the job manager
@@ -471,7 +471,7 @@ def run_extractions(
     output_folder: Path,
     samples_df_path: Path,
     max_locations_per_job: int = 500,
-    custom_job_options: Optional[Dict[str, Union[str, int]]] = None,
+    job_options: Optional[Dict[str, Union[str, int]]] = None,
     parallel_jobs: int = 2,
     restart_failed: bool = False,
     extract_value: int = 1,
@@ -491,7 +491,7 @@ def run_extractions(
         for which extractions need to be done
     max_locations_per_job : int, optional
         The maximum number of locations to extract per job, by default 500
-    custom_job_options : dict, optional
+    job_options : dict, optional
         Custom job options to set for the extraction, by default None (default options)
         Options that can be set explicitly include:
             - memory : str
@@ -521,7 +521,7 @@ def run_extractions(
         output_folder,
         samples_df_path,
         max_locations_per_job=max_locations_per_job,
-        custom_job_options=custom_job_options,
+        job_options=job_options,
         parallel_jobs=parallel_jobs,
         restart_failed=restart_failed,
         extract_value=extract_value,

--- a/src/worldcereal/extract/patch_meteo.py
+++ b/src/worldcereal/extract/patch_meteo.py
@@ -34,7 +34,7 @@ def create_job_patch_meteo(
     connection: openeo.DataCube,
     provider,
     connection_provider,
-    custom_job_options: Optional[Dict[str, Union[str, int]]] = None,
+    job_options: Optional[Dict[str, Union[str, int]]] = None,
 ) -> gpd.GeoDataFrame:
 
     start_date = row.start_date
@@ -76,13 +76,13 @@ def create_job_patch_meteo(
     valid_time = geometry.features[0].properties["valid_time"]
 
     # Set job options
-    job_options = copy.deepcopy(DEFAULT_JOB_OPTIONS_PATCH_METEO)
-    if custom_job_options:
-        job_options.update(custom_job_options)
+    final_job_options = copy.deepcopy(DEFAULT_JOB_OPTIONS_PATCH_METEO)
+    if job_options:
+        final_job_options.update(job_options)
 
     return cube.create_job(
         out_format="NetCDF",
         title=f"GFMAP_Extraction_AGERA5_{h3index}_{valid_time}",
         sample_by_feature=True,
-        job_options=job_options,
+        job_options=final_job_options,
     )

--- a/src/worldcereal/extract/patch_s1.py
+++ b/src/worldcereal/extract/patch_s1.py
@@ -1,7 +1,8 @@
 """Extract S1 data using OpenEO-GFMAP package."""
 
+import copy
 from datetime import datetime
-from typing import List
+from typing import Dict, List, Optional, Union
 
 import geojson
 import geopandas as gpd
@@ -20,7 +21,7 @@ from tqdm import tqdm
 
 from worldcereal.openeo.preprocessing import raw_datacube_S1
 
-from worldcereal.extract.common import (  # isort: skip
+from worldcereal.extract.utils import (  # isort: skip
     buffer_geometry,  # isort: skip
     get_job_nb_polygons,  # isort: skip
     pipeline_log,  # isort: skip
@@ -28,6 +29,13 @@ from worldcereal.extract.common import (  # isort: skip
 )
 
 S1_GRD_CATALOGUE_BEGIN_DATE = datetime(2014, 10, 1)
+
+DEFAULT_JOB_OPTIONS_PATCH_S1 = {
+    "executor-memory": "1800m",
+    "python-memory": "1900m",
+    "max-executors": 22,
+    "soft-errors": "true",
+}
 
 
 def create_job_dataframe_patch_s1(
@@ -122,9 +130,7 @@ def create_job_patch_s1(
     connection: openeo.DataCube,
     provider,
     connection_provider,
-    executor_memory: str,
-    python_memory: str,
-    max_executors: int,
+    custom_job_options: Optional[Dict[str, Union[str, int]]] = None,
 ) -> openeo.BatchJob:
     """Creates an OpenEO BatchJob from the given row information. This job is a
     S1 patch of 32x32 pixels at 20m spatial resolution."""
@@ -170,12 +176,11 @@ def create_job_patch_s1(
     number_polygons = get_job_nb_polygons(row)
     pipeline_log.debug("Number of polygons to extract %s", number_polygons)
 
-    job_options = {
-        "executor-memory": executor_memory,
-        "python-memory": python_memory,
-        "soft-errors": "true",
-        "max_executors": max_executors,
-    }
+    # Set job options
+    job_options = copy.deepcopy(DEFAULT_JOB_OPTIONS_PATCH_S1)
+    if custom_job_options:
+        job_options.update(custom_job_options)
+
     return cube.create_job(
         out_format="NetCDF",
         title=f"GFMAP_Extraction_S1_{s2_tile}_{valid_time}_{orbit_state}",

--- a/src/worldcereal/extract/patch_s1.py
+++ b/src/worldcereal/extract/patch_s1.py
@@ -130,7 +130,7 @@ def create_job_patch_s1(
     connection: openeo.DataCube,
     provider,
     connection_provider,
-    custom_job_options: Optional[Dict[str, Union[str, int]]] = None,
+    job_options: Optional[Dict[str, Union[str, int]]] = None,
 ) -> openeo.BatchJob:
     """Creates an OpenEO BatchJob from the given row information. This job is a
     S1 patch of 32x32 pixels at 20m spatial resolution."""
@@ -177,14 +177,14 @@ def create_job_patch_s1(
     pipeline_log.debug("Number of polygons to extract %s", number_polygons)
 
     # Set job options
-    job_options = copy.deepcopy(DEFAULT_JOB_OPTIONS_PATCH_S1)
-    if custom_job_options:
-        job_options.update(custom_job_options)
+    final_job_options = copy.deepcopy(DEFAULT_JOB_OPTIONS_PATCH_S1)
+    if job_options:
+        final_job_options.update(job_options)
 
     return cube.create_job(
         out_format="NetCDF",
         title=f"GFMAP_Extraction_S1_{s2_tile}_{valid_time}_{orbit_state}",
         sample_by_feature=True,
-        job_options=job_options,
+        job_options=final_job_options,
         feature_id_property="sample_id",
     )

--- a/src/worldcereal/extract/patch_s2.py
+++ b/src/worldcereal/extract/patch_s2.py
@@ -88,7 +88,7 @@ def create_job_patch_s2(
     connection: openeo.DataCube,
     provider,
     connection_provider,
-    custom_job_options: Optional[Dict[str, Union[str, int]]] = None,
+    job_options: Optional[Dict[str, Union[str, int]]] = None,
 ) -> gpd.GeoDataFrame:
 
     start_date = row.start_date
@@ -148,14 +148,14 @@ def create_job_patch_s2(
     _log.debug("Number of polygons to extract %s", number_polygons)
 
     # Set job options
-    job_options = copy.deepcopy(DEFAULT_JOB_OPTIONS_PATCH_S2)
-    if custom_job_options:
-        job_options.update(custom_job_options)
+    final_job_options = copy.deepcopy(DEFAULT_JOB_OPTIONS_PATCH_S2)
+    if job_options:
+        final_job_options.update(job_options)
 
     return cube.create_job(
         out_format="NetCDF",
         title=f"GFMAP_Extraction_S2_{s2_tile}_{valid_time}",
         sample_by_feature=True,
-        job_options=job_options,
+        job_options=final_job_options,
         feature_id_property="sample_id",
     )

--- a/src/worldcereal/extract/patch_s2.py
+++ b/src/worldcereal/extract/patch_s2.py
@@ -1,7 +1,8 @@
 """Extract S2 data using OpenEO-GFMAP package."""
 
+import copy
 from datetime import datetime
-from typing import List
+from typing import Dict, List, Optional, Union
 
 import geojson
 import geopandas as gpd
@@ -13,7 +14,7 @@ from tqdm import tqdm
 
 from worldcereal.openeo.preprocessing import raw_datacube_S2
 
-from worldcereal.extract.common import (  # isort: skip
+from worldcereal.extract.utils import (  # isort: skip
     buffer_geometry,  # isort: skip
     get_job_nb_polygons,  # isort: skip
     upload_geoparquet_artifactory,  # isort: skip
@@ -21,6 +22,21 @@ from worldcereal.extract.common import (  # isort: skip
 
 
 S2_L2A_CATALOGUE_BEGIN_DATE = datetime(2017, 1, 1)
+
+
+DEFAULT_JOB_OPTIONS_PATCH_S2 = {
+    "driver-memory": "2G",
+    "driver-memoryOverhead": "2G",
+    "driver-cores": "1",
+    "executor-memory": "1800m",
+    "python-memory": "1900m",
+    "executor-cores": "1",
+    "max-executors": 22,
+    "soft-errors": "true",
+    "gdal-dataset-cache-size": 2,
+    "gdal-cachemax": 120,
+    "executor-threads-jvm": 1,
+}
 
 
 def create_job_dataframe_patch_s2(
@@ -72,10 +88,9 @@ def create_job_patch_s2(
     connection: openeo.DataCube,
     provider,
     connection_provider,
-    executor_memory: str,
-    python_memory: str,
-    max_executors: int,
+    custom_job_options: Optional[Dict[str, Union[str, int]]] = None,
 ) -> gpd.GeoDataFrame:
+
     start_date = row.start_date
     end_date = row.end_date
     temporal_context = TemporalContext(start_date, end_date)
@@ -132,19 +147,10 @@ def create_job_patch_s2(
     number_polygons = get_job_nb_polygons(row)
     _log.debug("Number of polygons to extract %s", number_polygons)
 
-    job_options = {
-        "driver-memory": "2G",
-        "driver-memoryOverhead": "2G",
-        "driver-cores": "1",
-        "executor-memory": executor_memory,
-        "python-memory": python_memory,
-        "executor-cores": "1",
-        "max-executors": max_executors,
-        "soft-errors": "true",
-        "gdal-dataset-cache-size": 2,
-        "gdal-cachemax": 120,
-        "executor-threads-jvm": 1,
-    }
+    # Set job options
+    job_options = copy.deepcopy(DEFAULT_JOB_OPTIONS_PATCH_S2)
+    if custom_job_options:
+        job_options.update(custom_job_options)
 
     return cube.create_job(
         out_format="NetCDF",

--- a/src/worldcereal/extract/patch_worldcereal.py
+++ b/src/worldcereal/extract/patch_worldcereal.py
@@ -134,7 +134,7 @@ def create_job_patch_worldcereal(
     connection: openeo.DataCube,
     provider,
     connection_provider,
-    custom_job_options: Optional[Dict[str, Union[str, int]]] = None,
+    job_options: Optional[Dict[str, Union[str, int]]] = None,
 ) -> openeo.BatchJob:
     """Creates an OpenEO BatchJob from the given row information."""
 
@@ -198,15 +198,15 @@ def create_job_patch_worldcereal(
     pipeline_log.debug("Number of polygons to extract %s", number_polygons)
 
     # Set job options
-    job_options = copy.deepcopy(DEFAULT_JOB_OPTIONS_PATCH_WORLDCEREAL)
-    if custom_job_options:
-        job_options.update(custom_job_options)
+    final_job_options = copy.deepcopy(DEFAULT_JOB_OPTIONS_PATCH_WORLDCEREAL)
+    if job_options:
+        final_job_options.update(job_options)
 
     return cube.create_job(
         out_format="NetCDF",
         title=f"GFMAP_Extraction_WORLDCEREAL_{s2_tile}_{valid_time}",
         sample_by_feature=True,
-        job_options=job_options,
+        job_options=final_job_options,
         feature_id_property="sample_id",
     )
 

--- a/src/worldcereal/extract/patch_worldcereal.py
+++ b/src/worldcereal/extract/patch_worldcereal.py
@@ -1,11 +1,12 @@
 """Extract WorldCereal preprocessed inputs using OpenEO-GFMAP package."""
 
+import copy
 import json
 import shutil
 from datetime import datetime
 from importlib.metadata import version
 from pathlib import Path
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import geojson
 import geopandas as gpd
@@ -32,14 +33,23 @@ from worldcereal.openeo.preprocessing import (
 )
 from worldcereal.utils.geoloader import load_reproject
 
-from worldcereal.extract.common import (  # isort: skip
+from worldcereal.extract.utils import (  # isort: skip
     get_job_nb_polygons,  # isort: skip
     pipeline_log,  # isort: skip
     upload_geoparquet_artifactory,  # isort: skip
+    S2_GRID,  # isort: skip
 )
 
 
 WORLDCEREAL_BEGIN_DATE = datetime(2017, 1, 1)
+
+
+DEFAULT_JOB_OPTIONS_PATCH_WORLDCEREAL = {
+    "executor-memory": "1800m",
+    "python-memory": "3000m",
+    "soft-errors": "true",
+    "max_executors": 22,
+}
 
 
 def create_job_dataframe_patch_worldcereal(
@@ -124,9 +134,7 @@ def create_job_patch_worldcereal(
     connection: openeo.DataCube,
     provider,
     connection_provider,
-    executor_memory: str,
-    python_memory: str,
-    max_executors: int,
+    custom_job_options: Optional[Dict[str, Union[str, int]]] = None,
 ) -> openeo.BatchJob:
     """Creates an OpenEO BatchJob from the given row information."""
 
@@ -189,12 +197,11 @@ def create_job_patch_worldcereal(
     number_polygons = get_job_nb_polygons(row)
     pipeline_log.debug("Number of polygons to extract %s", number_polygons)
 
-    job_options = {
-        "executor-memory": executor_memory,
-        "python-memory": python_memory,
-        "soft-errors": "true",
-        "max_executors": max_executors,
-    }
+    # Set job options
+    job_options = copy.deepcopy(DEFAULT_JOB_OPTIONS_PATCH_WORLDCEREAL)
+    if custom_job_options:
+        job_options.update(custom_job_options)
+
     return cube.create_job(
         out_format="NetCDF",
         title=f"GFMAP_Extraction_WORLDCEREAL_{s2_tile}_{valid_time}",
@@ -327,9 +334,6 @@ def post_job_action_patch_worldcereal(
     job_items: List[pystac.Item],
     row: pd.Series,
     extract_value: int,
-    description: str,
-    title: str,
-    spatial_resolution: str,
 ) -> list:
     """From the job items, extract the metadata and save it in a netcdf file."""
     base_gpd = gpd.GeoDataFrame.from_features(json.loads(row.geometry)).set_crs(
@@ -373,10 +377,10 @@ def post_job_action_patch_worldcereal(
             "valid_time": valid_time,
             "GFMAP_version": version("openeo_gfmap"),
             "creation_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-            "description": description,
-            "title": title,
+            "description": "WorldCereal preprocessed inputs",
+            "title": "WorldCereal inputs",
             "sample_id": sample_id,
-            "spatial_resolution": spatial_resolution,
+            "spatial_resolution": "10m",
             "s2_tile": s2_tile,
             "_FillValue": 65535,  # No data value for uint16
         }
@@ -392,7 +396,6 @@ def generate_output_path_patch_worldcereal(
     job_index: int,
     row: pd.Series,
     asset_id: str,
-    s2_grid: gpd.GeoDataFrame,
 ):
     """Generate the output path for the extracted data, from a base path and
     the row information.
@@ -400,7 +403,7 @@ def generate_output_path_patch_worldcereal(
     sample_id = asset_id.replace(".nc", "").replace("openEO_", "")
 
     s2_tile_id = row.s2_tile
-    epsg = s2_grid[s2_grid.tile == s2_tile_id].iloc[0].epsg
+    epsg = S2_GRID[S2_GRID.tile == s2_tile_id].iloc[0].epsg
 
     return (
         root_folder

--- a/src/worldcereal/extract/point_worldcereal.py
+++ b/src/worldcereal/extract/point_worldcereal.py
@@ -1,8 +1,9 @@
 """Extract S1, S2, METEO and DEM point data using OpenEO-GFMAP package."""
 
+import copy
 import os
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import duckdb
 import geojson
@@ -13,8 +14,19 @@ import pystac
 from openeo_gfmap import Backend, BackendContext, FetchType, TemporalContext
 from tqdm import tqdm
 
-from worldcereal.extract.common import get_job_nb_polygons, pipeline_log
+from worldcereal.extract.utils import get_job_nb_polygons, pipeline_log
 from worldcereal.openeo.preprocessing import worldcereal_preprocessed_inputs
+
+DEFAULT_JOB_OPTIONS_POINT_WORLDCEREAL = {
+    "driver-memory": "2G",
+    "driver-memoryOverhead": "2G",
+    "driver-cores": "1",
+    "executor-memory": "1800m",
+    "python-memory": "3000m",
+    "executor-cores": "1",
+    "max-executors": 22,
+    "soft-errors": "true",
+}
 
 
 def generate_output_path_point_worldcereal(
@@ -111,9 +123,7 @@ def create_job_point_worldcereal(
     connection: openeo.DataCube,
     provider,
     connection_provider,
-    executor_memory: str,
-    python_memory: str,
-    max_executors: int,
+    custom_job_options: Optional[Dict[str, Union[str, int]]] = None,
 ):
     """Creates an OpenEO BatchJob from the given row information."""
 
@@ -154,16 +164,10 @@ def create_job_point_worldcereal(
     if pipeline_log is not None:
         pipeline_log.debug("Number of polygons to extract %s", number_points)
 
-    job_options = {
-        "driver-memory": "2G",
-        "driver-memoryOverhead": "2G",
-        "driver-cores": "1",
-        "executor-memory": executor_memory,
-        "python-memory": python_memory,
-        "executor-cores": "1",
-        "max-executors": max_executors,
-        "soft-errors": "true",
-    }
+    # Set job options
+    job_options = copy.deepcopy(DEFAULT_JOB_OPTIONS_POINT_WORLDCEREAL)
+    if custom_job_options:
+        job_options.update(custom_job_options)
 
     return cube.create_job(
         out_format="Parquet",

--- a/src/worldcereal/extract/point_worldcereal.py
+++ b/src/worldcereal/extract/point_worldcereal.py
@@ -123,7 +123,7 @@ def create_job_point_worldcereal(
     connection: openeo.DataCube,
     provider,
     connection_provider,
-    custom_job_options: Optional[Dict[str, Union[str, int]]] = None,
+    job_options: Optional[Dict[str, Union[str, int]]] = None,
 ):
     """Creates an OpenEO BatchJob from the given row information."""
 
@@ -165,14 +165,14 @@ def create_job_point_worldcereal(
         pipeline_log.debug("Number of polygons to extract %s", number_points)
 
     # Set job options
-    job_options = copy.deepcopy(DEFAULT_JOB_OPTIONS_POINT_WORLDCEREAL)
-    if custom_job_options:
-        job_options.update(custom_job_options)
+    final_job_options = copy.deepcopy(DEFAULT_JOB_OPTIONS_POINT_WORLDCEREAL)
+    if job_options:
+        final_job_options.update(job_options)
 
     return cube.create_job(
         out_format="Parquet",
         title=f"Worldcereal_Point_Extraction_{row.s2_tile}",
-        job_options=job_options,
+        job_options=final_job_options,
     )
 
 

--- a/src/worldcereal/extract/utils.py
+++ b/src/worldcereal/extract/utils.py
@@ -1,0 +1,121 @@
+"""Common utilities used by extraction scripts."""
+
+import logging
+import os
+from tempfile import NamedTemporaryFile
+
+import geojson
+import geopandas as gpd
+import pandas as pd
+import requests
+from openeo_gfmap.manager.job_splitters import load_s2_grid
+from shapely import Point
+
+# Logger used for the pipeline
+pipeline_log = logging.getLogger("extraction_pipeline")
+
+pipeline_log.setLevel(level=logging.INFO)
+
+stream_handler = logging.StreamHandler()
+pipeline_log.addHandler(stream_handler)
+
+formatter = logging.Formatter("%(asctime)s|%(name)s|%(levelname)s:  %(message)s")
+stream_handler.setFormatter(formatter)
+
+
+# Exclude the other loggers from other libraries
+class ManagerLoggerFilter(logging.Filter):
+    """Filter to only accept the OpenEO-GFMAP manager logs."""
+
+    def filter(self, record):
+        return record.name in [pipeline_log.name]
+
+
+stream_handler.addFilter(ManagerLoggerFilter())
+
+
+S2_GRID = load_s2_grid()
+
+
+def buffer_geometry(
+    geometries: geojson.FeatureCollection, distance_m: int = 320
+) -> gpd.GeoDataFrame:
+    """For each geometry of the colleciton, perform a square buffer of 320
+    meters on the centroid and return the GeoDataFrame. Before buffering,
+    the centroid is clipped to the closest 20m multiplier in order to stay
+    aligned with the Sentinel-1 pixel grid.
+    """
+    gdf = gpd.GeoDataFrame.from_features(geometries).set_crs(epsg=4326)
+    utm = gdf.estimate_utm_crs()
+    gdf = gdf.to_crs(utm)
+
+    # Perform the buffering operation
+    gdf["geometry"] = gdf.centroid.apply(
+        lambda point: Point(round(point.x / 20.0) * 20.0, round(point.y / 20.0) * 20.0)
+    ).buffer(
+        distance=distance_m, cap_style=3
+    )  # Square buffer
+
+    return gdf
+
+
+def filter_extract_true(
+    geometries: geojson.FeatureCollection, extract_value: int = 1
+) -> gpd.GeoDataFrame:
+    """Remove all the geometries from the Feature Collection that have the property field `extract` set to `False`"""
+    return geojson.FeatureCollection(
+        [
+            f
+            for f in geometries.features
+            if f.properties.get("extract", 0) == extract_value
+        ]
+    )
+
+
+def upload_geoparquet_artifactory(
+    gdf: gpd.GeoDataFrame, name: str, collection: str = ""
+) -> str:
+    """Upload the given GeoDataFrame to artifactory and return the URL of the
+    uploaded file. Necessary as a workaround for Polygon sampling in OpenEO
+    using custom CRS.
+    """
+    # Save the dataframe as geoparquet to upload it to artifactory
+    temporary_file = NamedTemporaryFile()
+    gdf.to_parquet(temporary_file.name)
+
+    artifactory_username = os.getenv("ARTIFACTORY_USERNAME")
+    artifactory_password = os.getenv("ARTIFACTORY_PASSWORD")
+
+    if not artifactory_username or not artifactory_password:
+        raise ValueError(
+            "Artifactory credentials not found. Please set ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD."
+        )
+
+    headers = {"Content-Type": "application/octet-stream"}
+
+    upload_url = f"https://artifactory.vgt.vito.be/artifactory/auxdata-public/gfmap-temp/openeogfmap_dataframe_{collection}{name}.parquet"
+
+    with open(temporary_file.name, "rb") as f:
+        response = requests.put(
+            upload_url,
+            headers=headers,
+            data=f,
+            auth=(artifactory_username, artifactory_password),
+            timeout=180,
+        )
+
+    response.raise_for_status()
+
+    return upload_url
+
+
+def get_job_nb_polygons(row: pd.Series) -> int:
+    """Get the number of polygons in the geometry."""
+    return len(
+        list(
+            filter(
+                lambda feat: feat.properties.get("extract"),
+                geojson.loads(row.geometry)["features"],
+            )
+        )
+    )

--- a/src/worldcereal/utils/retry.py
+++ b/src/worldcereal/utils/retry.py
@@ -1,0 +1,152 @@
+import functools
+import random
+import time
+from functools import partial
+
+from loguru import logger
+
+
+def decorator(caller):
+    """Turns caller into a decorator.
+    Unlike decorator module, function signature is not preserved.
+    :param caller: caller(f, *args, **kwargs)
+    """
+
+    def decor(f):
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            return caller(f, *args, **kwargs)
+
+        return wrapper
+
+    return decor
+
+
+def __retry_internal(
+    f,
+    exceptions=Exception,
+    tries=-1,
+    delay=0,
+    max_delay=None,
+    backoff=1,
+    jitter=0,
+    logger=logger,
+):
+    """
+    Executes a function and retries it if it failed.
+    :param f: the function to execute.
+    :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
+    :param tries: the maximum number of attempts. default: -1 (infinite).
+    :param delay: initial delay between attempts. default: 0.
+    :param max_delay: the maximum value of delay. default: None (no limit).
+    :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
+    :param jitter: extra seconds added to delay between attempts. default: 0.
+                   fixed if a number, random if a range tuple (min, max)
+    :param logger: logger.warning(fmt, error, delay) will be called on failed attempts.
+                   default: retry.logger. if None, logging is disabled.
+    :returns: the result of the f function.
+    """
+    _tries, _delay = tries, delay
+    while _tries:
+        try:
+            return f()
+        except exceptions as e:
+            _tries -= 1
+            if not _tries:
+                raise
+
+            if logger is not None:
+                logger.warning(f'Error "{e}", retrying in {_delay} seconds...')
+
+            time.sleep(_delay)
+            _delay *= backoff
+
+            if isinstance(jitter, tuple):
+                _delay += random.uniform(*jitter)
+            else:
+                _delay += jitter
+
+            if max_delay is not None:
+                _delay = min(_delay, max_delay)
+
+
+def retry(
+    exceptions=Exception,
+    tries=-1,
+    delay=0,
+    max_delay=None,
+    backoff=1,
+    jitter=0,
+    logger=logger,
+):
+    """Returns a retry decorator.
+    :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
+    :param tries: the maximum number of attempts. default: -1 (infinite).
+    :param delay: initial delay between attempts. default: 0.
+    :param max_delay: the maximum value of delay. default: None (no limit).
+    :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
+    :param jitter: extra seconds added to delay between attempts. default: 0.
+                   fixed if a number, random if a range tuple (min, max)
+    :param logger: logger.warning(fmt, error, delay) will be called on failed attempts.
+                   default: retry.logger. if None, logging is disabled.
+    :returns: a retry decorator.
+    """
+
+    @decorator
+    def retry_decorator(f, *fargs, **fkwargs):
+        args = fargs if fargs else []
+        kwargs = fkwargs if fkwargs else {}
+        return __retry_internal(
+            partial(f, *args, **kwargs),
+            exceptions,
+            tries,
+            delay,
+            max_delay,
+            backoff,
+            jitter,
+            logger,
+        )
+
+    return retry_decorator
+
+
+def retry_call(
+    f,
+    fargs=None,
+    fkwargs=None,
+    exceptions=Exception,
+    tries=-1,
+    delay=0,
+    max_delay=None,
+    backoff=1,
+    jitter=0,
+    logger=logger,
+):
+    """
+    Calls a function and re-executes it if it failed.
+    :param f: the function to execute.
+    :param fargs: the positional arguments of the function to execute.
+    :param fkwargs: the named arguments of the function to execute.
+    :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
+    :param tries: the maximum number of attempts. default: -1 (infinite).
+    :param delay: initial delay between attempts. default: 0.
+    :param max_delay: the maximum value of delay. default: None (no limit).
+    :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
+    :param jitter: extra seconds added to delay between attempts. default: 0.
+                   fixed if a number, random if a range tuple (min, max)
+    :param logger: logger.warning(fmt, error, delay) will be called on failed attempts.
+                   default: retry.logger. if None, logging is disabled.
+    :returns: the result of the f function.
+    """
+    args = fargs if fargs else []
+    kwargs = fkwargs if fkwargs else {}
+    return __retry_internal(
+        partial(f, *args, **kwargs),
+        exceptions,
+        tries,
+        delay,
+        max_delay,
+        backoff,
+        jitter,
+        logger,
+    )


### PR DESCRIPTION
Core functions previously in scripts > extract.py have been moved to src > extractions > common.py

Functionality has been split into 3 "stages" (prepare extractions, run extractions and merge extractions).
This has been deliberately done to support running extractions using push notifications in scripts > extract.py. The way in which the extractions are fired up there, has not been changed.

Some key consequences:
- some common util functions have been moved from common.py to src > extractions > utils.py to avoid circular imports
- default job options have been defined for each type of extractions in the respective files (e.g. DEFAULT_JOB_OPTIONS_POINT_WORLDCEREAL).
- instead of having 3 separate arguments (memory, python_memory and max_executors), I propose to have a "custom_job_options" option for more advanced users that want to change specific job options.
