### PR TITLE
Support `BaseGeometry` as input for `RdmInteraction.get_samples()`

### DIFF
--- a/src/worldcereal/rdm_api/rdm_interaction.py
+++ b/src/worldcereal/rdm_api/rdm_interaction.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import duckdb
 import geopandas as gpd
@@ -18,6 +18,7 @@ from openeo_gfmap import BoundingBoxExtent, TemporalContext
 from requests.adapters import HTTPAdapter
 from shapely import wkb
 from shapely.geometry import Polygon
+from shapely.geometry.base import BaseGeometry
 from urllib3.util.retry import Retry
 
 from worldcereal.rdm_api.rdm_collection import RdmCollection
@@ -109,7 +110,7 @@ class RdmInteraction:
 
     def get_collections(
         self,
-        bbox: Optional[BoundingBoxExtent] = None,
+        spatial_extent: Optional[Union[BoundingBoxExtent, BaseGeometry]] = None,
         temporal_extent: Optional[TemporalContext] = None,
         include_public: Optional[bool] = True,
         include_private: Optional[bool] = False,
@@ -120,8 +121,8 @@ class RdmInteraction:
 
         Parameters
         ----------
-        bbox : Optional[BoundingBoxExtent], optional
-            A user-defined bounding box for which all intersecting collections need to be found.
+        spatial_extent : Optional[Union[BoundingBoxExtent, BaseGeometry]], optional
+            A user-defined bounding box, or geometry for which all intersecting collections need to be found.
             CRS should be EPSG:4326.
             If None, all available data will be queried, by default None
         temporal_extent : Optional[TemporalContext], optional
@@ -148,16 +149,29 @@ class RdmInteraction:
                 self.authenticate()
 
         # Handle geometry
-        if bbox is None:
-            bbox = BoundingBoxExtent(
+        if isinstance(spatial_extent, BaseGeometry):
+            spatial_extent = spatial_extent.bounds
+            spatial_extent = BoundingBoxExtent(
+                west=spatial_extent[0],
+                south=spatial_extent[1],
+                east=spatial_extent[2],
+                north=spatial_extent[3],
+                epsg=4326,
+            )
+
+        if spatial_extent is None:
+            spatial_extent = BoundingBoxExtent(
                 west=-180, south=-90, east=180, north=90, epsg=4326
             )
         # check if the geometry is valid
-        if bbox.west < -180 or bbox.south < -90 or bbox.east > 180 or bbox.north > 90:
+        if (
+            spatial_extent.west < -180
+            or spatial_extent.south < -90
+            or spatial_extent.east > 180
+            or spatial_extent.north > 90
+        ):
             raise ValueError("Invalid geometry. CRS should be EPSG:4326.")
-        bbox_str = (
-            f"Bbox={bbox.west}&Bbox={bbox.south}&Bbox={bbox.east}&Bbox={bbox.north}"
-        )
+        bbox_str = f"Bbox={spatial_extent.west}&Bbox={spatial_extent.south}&Bbox={spatial_extent.east}&Bbox={spatial_extent.north}"
 
         # Handle temporal extent
         val_time = (
@@ -310,7 +324,7 @@ class RdmInteraction:
     def _setup_sql_query(
         self,
         urls: List[str],
-        bbox: BoundingBoxExtent,
+        spatial_extent: Union[BoundingBoxExtent, BaseGeometry],
         columns: List[str],
         temporal_extent: Optional[TemporalContext] = None,
         ewoc_codes: Optional[List[int]] = None,
@@ -324,8 +338,8 @@ class RdmInteraction:
         ----------
         urls : List[str]
             A list of URLs of the GeoParquet files.
-        bbox : BoundingBoxExtent
-            A user-defined bounding box.
+        spatial_extent : Union[BoundingBoxExtent, BaseGeometry]
+            A user-defined bounding box, or geometry.
         columns :
             A list of column names to extract.
         temporal_extent : Optional[TemporalContext], optional
@@ -378,22 +392,29 @@ class RdmInteraction:
         )
 
         # Create a shapely polygon from the bounding box
-        geometry = Polygon(
-            [
-                (bbox.west, bbox.south),
-                (bbox.east, bbox.south),
-                (bbox.east, bbox.north),
-                (bbox.west, bbox.north),
-                (bbox.west, bbox.south),
-            ]
-        )
+        if isinstance(spatial_extent, BoundingBoxExtent):
+            geometry = Polygon(
+                [
+                    (spatial_extent.west, spatial_extent.south),
+                    (spatial_extent.east, spatial_extent.south),
+                    (spatial_extent.east, spatial_extent.north),
+                    (spatial_extent.west, spatial_extent.north),
+                    (spatial_extent.west, spatial_extent.south),
+                ]
+            )
+        else:
+            if not isinstance(spatial_extent, BaseGeometry):
+                raise ValueError(
+                    "Spatial extent should be either a BoundingBoxExtent or a shapely.BaseGeometry."
+                )
+            geometry = spatial_extent
 
         for i, url in enumerate(urls):
             ref_id = str(url).split("/")[-2]
             query = f"""
-                SELECT {columns_str}, ST_AsWKB(ST_Intersection(ST_MakeValid(geometry), ST_GeomFromText('{str(geometry)}'))) AS wkb_geometry, '{ref_id}' AS ref_id
+                SELECT {columns_str}, ST_AsWKB(ST_Intersection(ST_MakeValid(ST_Simplify(geometry, 0.001)), ST_Simplify(ST_GeomFromText('{str(geometry)}'), 0.001))) AS wkb_geometry, '{ref_id}' AS ref_id
                 FROM read_parquet('{url}')
-                WHERE ST_Intersects(ST_MakeValid(geometry), ST_GeomFromText('{str(geometry)}'))
+                WHERE ST_Intersects(ST_MakeValid(ST_Simplify(geometry, 0.001)), ST_Simplify(ST_GeomFromText('{str(geometry)}'), 0.001))
                 {optional_temporal}
                 {optional_ewoc_codes}
                 {optional_subset}
@@ -412,7 +433,7 @@ class RdmInteraction:
         ref_ids: Optional[List[str]] = None,
         columns: List[str] = DEFAULT_COLUMNS,
         subset: Optional[bool] = False,
-        bbox: Optional[BoundingBoxExtent] = None,
+        spatial_extent: Optional[Union[BoundingBoxExtent, BaseGeometry]] = None,
         temporal_extent: Optional[TemporalContext] = None,
         ewoc_codes: Optional[List[int]] = None,
         include_public: Optional[bool] = True,
@@ -434,8 +455,8 @@ class RdmInteraction:
             If True, only download a subset of the samples (for which extract attribute ==1)
             If False, extract all samples.
             Default is False.
-        bbox : Optional[BoundingBoxExtent], optional
-            A user-defined bounding box for which all intersecting samples need to be found.
+        spatial_extent : Optional[Union[BoundingBoxExtent, BaseGeometry]], optional
+            A user-defined bounding box or geometry for which all intersecting samples need to be found.
             CRS should be EPSG:4326.
             If None, all available data will be queried, by default None
         temporal_extent : TemporalContext, optional
@@ -461,7 +482,7 @@ class RdmInteraction:
         # Determine which collections need to be queried if they are not specified
         if not ref_ids:
             collections = self.get_collections(
-                bbox=bbox,
+                spatial_extent=spatial_extent,
                 temporal_extent=temporal_extent,
                 ewoc_codes=ewoc_codes,
                 include_public=include_public,
@@ -479,16 +500,16 @@ class RdmInteraction:
         # For each collection, get the download URL
         urls = self._get_download_urls(ref_ids)
 
-        # Ensure we have a valid bbox
-        if bbox is None:
-            bbox = BoundingBoxExtent(
+        # Ensure we have a valid spatial_extent
+        if spatial_extent is None:
+            spatial_extent = BoundingBoxExtent(
                 west=-180, south=-90, east=180, north=90, epsg=4326
             )
 
         # Set up the SQL query
         query = self._setup_sql_query(
             urls=urls,
-            bbox=bbox,
+            spatial_extent=spatial_extent,
             columns=columns,
             temporal_extent=temporal_extent,
             ewoc_codes=ewoc_codes,

--- a/src/worldcereal/rdm_api/rdm_interaction.py
+++ b/src/worldcereal/rdm_api/rdm_interaction.py
@@ -412,9 +412,9 @@ class RdmInteraction:
         for i, url in enumerate(urls):
             ref_id = str(url).split("/")[-2]
             query = f"""
-                SELECT {columns_str}, ST_AsWKB(ST_Intersection(ST_MakeValid(ST_Simplify(geometry, 0.001)), ST_Simplify(ST_GeomFromText('{str(geometry)}'), 0.001))) AS wkb_geometry, '{ref_id}' AS ref_id
+                SELECT {columns_str}, ST_AsWKB(ST_Intersection(ST_MakeValid(ST_Simplify(geometry, 0.000001)), ST_Simplify(ST_GeomFromText('{str(geometry)}'), 0.000001))) AS wkb_geometry, '{ref_id}' AS ref_id
                 FROM read_parquet('{url}')
-                WHERE ST_Intersects(ST_MakeValid(ST_Simplify(geometry, 0.001)), ST_Simplify(ST_GeomFromText('{str(geometry)}'), 0.001))
+                WHERE ST_Intersects(ST_MakeValid(ST_Simplify(geometry, 0.000001)), ST_Simplify(ST_GeomFromText('{str(geometry)}'), 0.000001))
                 {optional_temporal}
                 {optional_ewoc_codes}
                 {optional_subset}

--- a/src/worldcereal/rdm_api/rdm_interaction.py
+++ b/src/worldcereal/rdm_api/rdm_interaction.py
@@ -17,7 +17,7 @@ from openeo.rest.auth.oidc import (
 from openeo_gfmap import BoundingBoxExtent, TemporalContext
 from requests.adapters import HTTPAdapter
 from shapely import wkb
-from shapely.geometry import Polygon
+from shapely.geometry import Point, Polygon
 from shapely.geometry.base import BaseGeometry
 from urllib3.util.retry import Retry
 
@@ -765,6 +765,11 @@ class RdmInteraction:
         """
 
         if isinstance(spatial_extent, BaseGeometry):
+            if not isinstance(spatial_extent, Point):
+                raise ValueError(
+                    "Spatial extent cannot be a shapely.geometry.Point object"
+                )
+
             spatial_extent = spatial_extent.bounds
             spatial_extent = BoundingBoxExtent(
                 west=spatial_extent[0],

--- a/tests/worldcerealtests/test_rdm_interaction.py
+++ b/tests/worldcerealtests/test_rdm_interaction.py
@@ -39,7 +39,7 @@ class TestRdmInteraction:
         ]
         interaction = RdmInteraction()
         collections = interaction.get_collections(
-            bbox=sample_bbox, temporal_extent=sample_temporal_extent
+            spatial_extent=sample_bbox, temporal_extent=sample_temporal_extent
         )
         ref_ids = [collection.id for collection in collections]
 
@@ -106,7 +106,7 @@ class TestRdmInteraction:
 
         interaction = RdmInteraction()
         result_gdf = interaction.get_samples(
-            bbox=sample_bbox,
+            spatial_extent=sample_bbox,
             temporal_extent=sample_temporal_extent,
             columns=["col1", "col2", "ref_id", "geometry"],
             ewoc_codes=["1", "2", "3", "4"],


### PR DESCRIPTION
- The `bbox` argument for  `RdmInteraction.get_samples()` has been renamed to `spatial_extent`
- `spatial_extent` can now both be a `BoundingBoxExtent` or a `BaseGeometry`
- In the SQL query to the RDM an extra `ST_Simplify` has been added to the geometries to avoid `TopologyException`