### PR TITLE
More efficient parquet loading

### DIFF
--- a/src/worldcereal/extract/common.py
+++ b/src/worldcereal/extract/common.py
@@ -665,7 +665,6 @@ def _run_extraction_jobs(
 
 
 def _merge_extraction_jobs(
-    collection: ExtractionCollection,
     output_folder: Path,
     ref_id: str,
 ) -> None:
@@ -673,8 +672,6 @@ def _merge_extraction_jobs(
 
     Parameters
     ----------
-    collection : ExtractionCollection
-        The collection to extract. Most popular: PATCH_WORLDCEREAL, POINT_WORLDCEREAL
     output_folder : Path
         Location where extractions are stored.
     ref_id : str
@@ -683,13 +680,9 @@ def _merge_extraction_jobs(
 
     # Merge the extraction jobs
     pipeline_log.info("Merging the extraction jobs.")
-
-    if collection == ExtractionCollection.POINT_WORLDCEREAL:
-        pipeline_log.info("Merging Geoparquet results...")
-        merge_output_files_point_worldcereal(output_folder, ref_id)
-        pipeline_log.info("Geoparquet results merged successfully.")
-
-    return
+    pipeline_log.info("Merging Geoparquet results...")
+    merge_output_files_point_worldcereal(output_folder, ref_id)
+    pipeline_log.info("Geoparquet results merged successfully.")
 
 
 def run_extractions(
@@ -757,12 +750,14 @@ def run_extractions(
     # Run the extraction jobs
     _run_extraction_jobs(job_manager, job_df, datacube_fn, tracking_df_path)
 
-    # get ref_id from samples df
-    samples_gdf = load_dataframe(samples_df_path)
-    ref_id = samples_gdf.iloc[0]["ref_id"]
-
     # Merge the extraction jobs (for point extractions)
-    _merge_extraction_jobs(collection, output_folder, ref_id)
+    if collection == ExtractionCollection.POINT_WORLDCEREAL:
+        # get ref_id from samples df
+        samples_gdf = load_dataframe(samples_df_path)
+        ref_id = samples_gdf.iloc[0]["ref_id"]
+
+        # Merge extractions
+        _merge_extraction_jobs(output_folder, ref_id)
 
     pipeline_log.info("Extractions workflow completed.")
     pipeline_log.info(f"Results stored in folder: {output_folder}.")


### PR DESCRIPTION
This PR implements a filtering mechanism during parquet file loading which results in only loading rows with a `extract` value `>= extract_value`. This avoids loading first the entire parquet file (in the example of French GSAA data this even gets killed due to the high amount of features) and only then filtering for extract value.