### PR TITLE
Improvements for (patch) extractions

### DIFF
--- a/scripts/extractions/extract.py
+++ b/scripts/extractions/extract.py
@@ -25,6 +25,7 @@ def main(
     extract_value: int = 1,
     backend=Backend.CDSE,
     write_stac_api: bool = False,
+    image_name: Optional[str] = None,
 ) -> None:
     """Main function responsible for launching point and patch extractions.
 
@@ -60,6 +61,8 @@ def main(
         cloud backend where to run the extractions, by default Backend.CDSE
     write_stac_api : bool, optional
         Save metadata of extractions to STAC API (requires authentication), by default False
+    image_name : str, optional
+        Specific openEO image name to use for the jobs, by default None
 
     Returns
     -------
@@ -73,6 +76,7 @@ def main(
             "memory": memory,
             "python_memory": python_memory,
             "max_executors": max_executors,
+            "image-name": image_name,
         }.items()
         if value is not None
     } or None
@@ -161,6 +165,12 @@ if __name__ == "__main__":
         default=False,
         help="Flag to write S1 and S2 patch extraction results to STAC API or not.",
     )
+    parser.add_argument(
+        "--image_name",
+        type=str,
+        default=None,
+        help="Specific openEO image name to use for the jobs.",
+    )
 
     args = parser.parse_args()
 
@@ -178,4 +188,5 @@ if __name__ == "__main__":
         extract_value=args.extract_value,
         backend=Backend.CDSE,
         write_stac_api=args.write_stac_api,
+        image_name=args.image_name,
     )

--- a/scripts/extractions/extract.py
+++ b/scripts/extractions/extract.py
@@ -15,6 +15,7 @@ def main(
     collection: ExtractionCollection,
     output_folder: Path,
     samples_df_path: Path,
+    ref_id: str,
     max_locations_per_job: int = 500,
     memory: Optional[str] = None,
     python_memory: Optional[str] = None,
@@ -36,6 +37,8 @@ def main(
     samples_df_path : Path
         Path to the input dataframe containing the geometries
         for which extractions need to be done
+    ref_id : str
+        Official ref_id of the source dataset
     max_locations_per_job : int, optional
         The maximum number of locations to extract per job, by default 500
     memory : str, optional
@@ -79,6 +82,7 @@ def main(
         collection,
         output_folder,
         samples_df_path,
+        ref_id,
         max_locations_per_job=max_locations_per_job,
         job_options=job_options,
         parallel_jobs=parallel_jobs,
@@ -106,6 +110,12 @@ if __name__ == "__main__":
         "samples_df_path",
         type=Path,
         help="Path to the samples dataframe with the data to extract",
+    )
+    parser.add_argument(
+        "--ref_id",
+        type=str,
+        required=True,
+        help="Official `ref_id` of the source dataset",
     )
     parser.add_argument(
         "--max_locations",
@@ -158,6 +168,7 @@ if __name__ == "__main__":
         collection=args.collection,
         output_folder=args.output_folder,
         samples_df_path=args.samples_df_path,
+        ref_id=args.ref_id,
         max_locations_per_job=args.max_locations,
         memory=args.memory,
         python_memory=args.python_memory,

--- a/src/worldcereal/extract/common.py
+++ b/src/worldcereal/extract/common.py
@@ -1,5 +1,6 @@
 """Common functions used by extraction scripts."""
 
+import grp
 import json
 import os
 import shutil
@@ -150,6 +151,9 @@ def post_job_action_patch(
         with NamedTemporaryFile(delete=False) as temp_file:
             ds.to_netcdf(temp_file.name)
             shutil.move(temp_file.name, item_asset_path)
+            os.chmod(item_asset_path, 0o755)
+            gid = grp.getgrnam("vito").gr_gid
+            shutil.chown(item_asset_path, group=gid)
 
         # Update the metadata of the item
         if write_stac_api:

--- a/src/worldcereal/extract/common.py
+++ b/src/worldcereal/extract/common.py
@@ -171,6 +171,14 @@ def post_job_action_patch(
         username = os.getenv("STAC_API_USERNAME")
         password = os.getenv("STAC_API_PASSWORD")
 
+        if not username or not password:
+            error_msg = (
+                "STAC API credentials not found. Please set "
+                "STAC_API_USERNAME and STAC_API_PASSWORD."
+            )
+            pipeline_log.error(error_msg)
+            raise ValueError(error_msg)
+
         stac_api_interaction = StacApiInteraction(
             sensor=sensor,
             base_url="https://stac.openeo.vito.be",

--- a/src/worldcereal/extract/common.py
+++ b/src/worldcereal/extract/common.py
@@ -550,6 +550,7 @@ def _prepare_extraction_jobs(
     collection: ExtractionCollection,
     output_folder: Path,
     samples_df_path: Path,
+    ref_id: str,
     max_locations_per_job: int = 500,
     job_options: Optional[Dict[str, Union[str, int]]] = None,
     parallel_jobs: int = 2,
@@ -570,6 +571,8 @@ def _prepare_extraction_jobs(
     samples_df_path : Path
         Path to the input dataframe containing the geometries
         for which extractions need to be done
+    ref_id : str
+        Official ref_id of the source dataset
     max_locations_per_job : int, optional
         The maximum number of locations to extract per job, by default 500
     job_options : Optional[Dict[str, Union[str, int]]], optional
@@ -624,6 +627,7 @@ def _prepare_extraction_jobs(
     else:
         # Load the input dataframe and build the job dataframe
         samples_gdf = load_dataframe(samples_df_path, extract_value)
+        samples_gdf["ref_id"] = ref_id
         pipeline_log.info("Creating new job tracking dataframe.")
         job_df = prepare_job_dataframe(
             samples_gdf, collection, max_locations_per_job, backend
@@ -702,6 +706,7 @@ def run_extractions(
     collection: ExtractionCollection,
     output_folder: Path,
     samples_df_path: Path,
+    ref_id: str,
     max_locations_per_job: int = 500,
     job_options: Optional[Dict[str, Union[str, int]]] = None,
     parallel_jobs: int = 2,
@@ -721,6 +726,8 @@ def run_extractions(
     samples_df_path : Path
         Path to the input dataframe containing the geometries
         for which extractions need to be done
+    ref_id : str
+        Official ref_id of the source dataset
     max_locations_per_job : int, optional
         The maximum number of locations to extract per job, by default 500
     job_options : Optional[Dict[str, Union[str, int]]], optional
@@ -751,6 +758,7 @@ def run_extractions(
         collection,
         output_folder,
         samples_df_path,
+        ref_id,
         max_locations_per_job=max_locations_per_job,
         job_options=job_options,
         parallel_jobs=parallel_jobs,
@@ -765,10 +773,6 @@ def run_extractions(
 
     # Merge the extraction jobs (for point extractions)
     if collection == ExtractionCollection.POINT_WORLDCEREAL:
-        # get ref_id from samples df
-        samples_gdf = load_dataframe(samples_df_path)
-        ref_id = samples_gdf.iloc[0]["ref_id"]
-
         # Merge extractions
         _merge_extraction_jobs(output_folder, ref_id)
 


### PR DESCRIPTION
Some improvements for extractions:
- we can now use a non-default openEO image
- `ref_id` is now compulsory argument to stay in full control on this (needs an update to the notebooks!)
- permissions of patch extractions are set correctly