### PR TITLE
Avoid global import of `grp` module

### DIFF
--- a/src/worldcereal/extract/common.py
+++ b/src/worldcereal/extract/common.py
@@ -1,6 +1,5 @@
 """Common functions used by extraction scripts."""
 
-import grp
 import json
 import os
 import shutil
@@ -113,6 +112,8 @@ def post_job_action_patch(
     sensor: str = "Sentinel1",
 ) -> list:
     """From the job items, extract the metadata and save it in a netcdf file."""
+
+    import grp
 
     # First do some basic quality checks to see if everything went right
     extraction_job_quality_check(row)


### PR DESCRIPTION
The `grp` module is required for setting permissions of WorldCereal patch extractions in a post-job action. This is not needed for the regular user-based extractions and besides, the `grp` module is only available on Unix systems. This PR avoids global import of this module.