### PR TITLE
Fix collect_inputs job options usage

### DIFF
--- a/src/worldcereal/job.py
+++ b/src/worldcereal/job.py
@@ -326,5 +326,5 @@ def collect_inputs(
         out_format="NetCDF",
         title="WorldCereal [collect_inputs] job",
         description="Job that collects inputs for WorldCereal inference",
-        job_options=job_options,
+        job_options=JOB_OPTIONS,
     )


### PR DESCRIPTION
## Summary
- ensure `collect_inputs` sends the merged job options to `execute_batch`

## Testing
- `pytest -q` *(fails: command not found)*