### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Next, install the package locally:
 - for Pip: `pip install .[train,notebooks]`
 
 ## Usage Example
-In it's most simple form, a cropland mask can be generated with just few lines of code, triggering an openEO job on CDSE and downloading the result locally:
+In its most simple form, a cropland mask can be generated with just few lines of code, triggering an openEO job on CDSE and downloading the result locally:
 
 ```python
 from openeo_gfmap import BoundingBoxExtent, TemporalContext

--- a/src/worldcereal/extract/patch_s1.py
+++ b/src/worldcereal/extract/patch_s1.py
@@ -44,7 +44,7 @@ def create_job_dataframe_patch_s1(
     backend: Backend,
     split_jobs: List[gpd.GeoDataFrame],
 ) -> pd.DataFrame:
-    """Create a dataframe from the split jobs, containg all the necessary information to run the job."""
+    """Create a dataframe from the split jobs, containing all the necessary information to run the job."""
     rows = []
     for job in tqdm(split_jobs):
         # Compute the average in the valid date and make a buffer of 1.5 year around

--- a/src/worldcereal/extract/patch_s2.py
+++ b/src/worldcereal/extract/patch_s2.py
@@ -45,7 +45,7 @@ def create_job_dataframe_patch_s2(
     backend: Backend,
     split_jobs: List[gpd.GeoDataFrame],
 ) -> pd.DataFrame:
-    """Create a dataframe from the split jobs, containg all the necessary information to run the job."""
+    """Create a dataframe from the split jobs, containing all the necessary information to run the job."""
     rows = []
     for job in tqdm(split_jobs):
         # Compute the average in the valid date and make a buffer of 1.5 year around

--- a/src/worldcereal/extract/patch_worldcereal.py
+++ b/src/worldcereal/extract/patch_worldcereal.py
@@ -55,7 +55,7 @@ def create_job_dataframe_patch_worldcereal(
     backend: Backend,
     split_jobs: List[gpd.GeoDataFrame],
 ) -> pd.DataFrame:
-    """Create a dataframe from the split jobs, containg all the necessary information to run the job."""
+    """Create a dataframe from the split jobs, containing all the necessary information to run the job."""
     rows = []
     for job in tqdm(split_jobs):
         # Compute the average in the valid date and make a buffer of 1.5 year around

--- a/src/worldcereal/extract/point_worldcereal.py
+++ b/src/worldcereal/extract/point_worldcereal.py
@@ -73,7 +73,7 @@ def generate_output_path_point_worldcereal(
 def create_job_dataframe_point_worldcereal(
     backend: Backend, split_jobs: List[gpd.GeoDataFrame]
 ) -> pd.DataFrame:
-    """Create a dataframe from the split jobs, containg all the necessary information to run the job."""
+    """Create a dataframe from the split jobs, containing all the necessary information to run the job."""
     rows = []
     for job in tqdm(split_jobs):
         min_time = job.valid_time.min()

--- a/src/worldcereal/extract/utils.py
+++ b/src/worldcereal/extract/utils.py
@@ -42,7 +42,7 @@ S2_GRID = load_s2_grid()
 def buffer_geometry(
     geometries: geojson.FeatureCollection, distance_m: int = 320
 ) -> gpd.GeoDataFrame:
-    """For each geometry of the colleciton, perform a square buffer of 320
+    """For each geometry of the collection, perform a square buffer of 320
     meters on the centroid and return the GeoDataFrame. Before buffering,
     the centroid is clipped to the closest 20m multiplier in order to stay
     aligned with the Sentinel-1 pixel grid.


### PR DESCRIPTION
## Summary
- correct typo in utils buffer_geometry docstring
- fix 'containing' typo across extraction scripts
- update README phrasing

## Testing
- `pytest -q` *(fails: command not found)*