### PR TITLE
Run inference workflow on Python 3.11 image of openeo

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - pip:
     - duckdb==1.1.3
     - h3==4.1.0
-    - openeo-gfmap==0.4.5
+    - openeo-gfmap==0.4.6
     - git+https://github.com/worldcereal/worldcereal-classification
     - git+https://github.com/WorldCereal/presto-worldcereal.git@croptype
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "netcdf4<=1.6.4",  
     "numpy<2.0.0",  
     "openeo==0.35.0",  
-    "openeo-gfmap==0.4.5",  
+    "openeo-gfmap==0.4.6",  
     "pyarrow",  
     "pydantic==2.8.0",  
     "rioxarray>=0.13.0",  

--- a/src/worldcereal/job.py
+++ b/src/worldcereal/job.py
@@ -20,7 +20,8 @@ from worldcereal.parameters import (
 )
 from worldcereal.utils.models import load_model_lut
 
-ONNX_DEPS_URL = "https://artifactory.vgt.vito.be/artifactory/auxdata-public/openeo/onnx_dependencies_1.16.3.zip"
+ONNX_DEPS_URL = "https://s3.waw3-1.cloudferro.com/swift/v1/project_dependencies/onnx_deps_python311.zip"
+FEATURE_DEPS_URL = "https://s3.waw3-1.cloudferro.com/swift/v1/project_dependencies/torch_deps_python311.zip"
 
 
 class WorldCerealProduct(TypedDict):
@@ -278,7 +279,11 @@ def generate_map(
         "executor-memoryOverhead": "1g",
         "python-memory": "3g",
         "soft-errors": 0.1,
-        "udf-dependency-archives": [f"{ONNX_DEPS_URL}#onnx_deps"],
+        "image-name": "python311",
+        "udf-dependency-archives": [
+            f"{ONNX_DEPS_URL}#onnx_deps",
+            f"{FEATURE_DEPS_URL}#feature_deps",
+        ],
     }
     if job_options is not None:
         JOB_OPTIONS.update(job_options)

--- a/src/worldcereal/openeo/feature_extractor.py
+++ b/src/worldcereal/openeo/feature_extractor.py
@@ -21,8 +21,6 @@ class PrestoFeatureExtractor(PatchFeatureExtractor):
     import functools
 
     PRESTO_WHL_URL = "https://artifactory.vgt.vito.be/artifactory/auxdata-public/worldcereal/dependencies/presto_worldcereal-0.1.6-py3-none-any.whl"
-    # BASE_URL = "https://s3.waw3-1.cloudferro.com/swift/v1/project_dependencies"  # NOQA
-    # DEPENDENCY_NAME = "worldcereal_deps.zip"
 
     GFMAP_BAND_MAPPING = {
         "S2-L2A-B02": "B2",
@@ -276,6 +274,14 @@ class PrestoFeatureExtractor(PatchFeatureExtractor):
         presto_wheel_url = self._parameters.get("presto_wheel_url", self.PRESTO_WHL_URL)
         self.logger.info(f'Loading Presto wheel from "{presto_wheel_url}"')
 
+        ignore_dependencies = self._parameters.get("ignore_dependencies", False)
+        if ignore_dependencies:
+            self.logger.info(
+                "`ignore_dependencies` flag is set to True. Make sure that "
+                "Presto and its dependencies are available on the runtime "
+                "environment"
+            )
+
         # The below is required to avoid flipping of the result
         # when running on OpenEO backend!
         inarr = inarr.transpose("bands", "t", "x", "y")
@@ -300,12 +306,14 @@ class PrestoFeatureExtractor(PatchFeatureExtractor):
                 )
             inarr.attrs["valid_date"] = inarr.t.values[6]
 
-        # Unzip the Presto dependencies on the backend
-        self.logger.info("Unpacking presto wheel")
-        deps_dir = self.unpack_presto_wheel(presto_wheel_url)
+        if not ignore_dependencies:
 
-        self.logger.info("Appending dependencies")
-        sys.path.append(str(deps_dir))
+            # Unzip the Presto dependencies on the backend
+            self.logger.info("Unpacking presto wheel")
+            deps_dir = self.unpack_presto_wheel(presto_wheel_url)
+
+            self.logger.info("Appending dependencies")
+            sys.path.append(str(deps_dir))
 
         from presto.inference import (  # pylint: disable=import-outside-toplevel
             get_presto_features,


### PR DESCRIPTION
- Updated gfmap dependency version to 0.4.6
- `generate_map` now executes a batch job on the python 3.11 image of openeo