### PR TITLE
Solve STAC merge conflicts

### DIFF
--- a/src/worldcereal/extract/common.py
+++ b/src/worldcereal/extract/common.py
@@ -200,7 +200,7 @@ def post_job_action_patch(
             actual_y_size = ds.dims.get("y", 0)
 
             if actual_x_size != expected_dim_size or actual_y_size != expected_dim_size:
-                pipeline_log.error(
+                pipeline_log.warning(
                     "Dimension validation failed for %s: expected %dx%d for %s resolution, got %dx%d",
                     item_asset_path,
                     expected_dim_size,
@@ -208,10 +208,6 @@ def post_job_action_patch(
                     spatial_resolution,
                     actual_x_size,
                     actual_y_size,
-                )
-                raise ValueError(
-                    f"Invalid dimensions for {spatial_resolution} resolution: "
-                    f"expected {expected_dim_size}x{expected_dim_size}, got {actual_x_size}x{actual_y_size}"
                 )
 
             pipeline_log.debug(


### PR DESCRIPTION
This PR handles residual issues from an older branch that added STAC check for existing extractions before creating a job dataframe https://github.com/WorldCereal/worldcereal-classification/pull/384

**Key changes:**

- downgraded `error` to `warning` for the dimension validation
- fixed the usage of collection objects (should be not strings)