### PR TITLE
Emit per-timestep logits with auxiliary attention regularizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ In order to run classification jobs on CDSE, users can get started with [monthly
 - **Powerful classification pipeline**: WorldCereal builds upon [Presto](https://arxiv.org/abs/2304.14065), a pretrained transformer-based model, leveraging global self-supervised learning of multimodal input timeseries, leading to better accuracies and higher generalizability in space and time of downstream crop classification models. The Presto backbone of WorldCereal classification pipelines is developed [here](https://github.com/WorldCereal/presto-worldcereal).
 - **Customizable**: Users can pick any region or temporal range and apply either default models or train their own and produce custom maps, interacting with publicly available training data.
 - **Easy to Use**: Integrates into Jupyter notebooks and other Python environments.
+- **Temporal logits with auxiliary attention**: Finetuned heads always emit per-timestep logits, while temporal attention weights remain optional diagnostics and can be regularised via auxiliary losses.
 
 ## Quick Start
 

--- a/docs/parameters_usage_guide.md
+++ b/docs/parameters_usage_guide.md
@@ -74,4 +74,4 @@ For croptype mapping:
 
 For cropland mapping:
 - `CropLandParameters()` - No target_date needed
-- Features are pooled across time (`temporal_prediction=False`)
+- Per-timestep logits are generated internally; with `temporal_prediction=False` the workflow selects the middle timestep downstream.

--- a/scripts/training/finetuning/finetune_presto.py
+++ b/scripts/training/finetuning/finetune_presto.py
@@ -65,6 +65,9 @@ def main(args):
     debug = args.debug
     use_balancing = args.use_balancing  # If True, use class balancing for training
     temporal_attention = args.temporal_attention
+    attn_kl_weight = args.attn_kl_weight
+    attn_entropy_weight = args.attn_entropy_weight
+    attn_warmup_epochs = args.attn_warmup_epochs
 
     # ± timesteps to jitter true label pos, for time_explicit only; will only be set for training
     label_jitter = args.label_jitter
@@ -213,6 +216,10 @@ def main(args):
         logger.info(
             "Temporal attention head enabled; using temporal priors as soft bias"
         )
+    else:
+        attn_kl_weight = 0.0
+        attn_entropy_weight = 0.0
+        attn_warmup_epochs = 0
 
     if apply_temporal_weights:
         logger.info(
@@ -289,7 +296,9 @@ def main(args):
         hyperparams=hyperparams,
         setup_logging=False,
         apply_temporal_weights=apply_temporal_weights,
-        attention_entropy_weight=0.02,
+        attn_kl_weight=attn_kl_weight,
+        attn_entropy_weight=attn_entropy_weight,
+        attn_warmup_epochs=attn_warmup_epochs,
         freeze_layers=freeze_layers,
         unfreeze_epoch=unfreeze_epoch,
     )
@@ -379,6 +388,24 @@ def parse_args(arg_list=None):
         type=int,
         default=0,
         help="Freeze encoder weights for this many initial epochs (0 disables freezing)",
+    )
+    parser.add_argument(
+        "--attn-kl-weight",
+        type=float,
+        default=0.0,
+        help="Weight of the KL term between attention and temporal kernel (temporal attention only)",
+    )
+    parser.add_argument(
+        "--attn-entropy-weight",
+        type=float,
+        default=0.0,
+        help="Weight of the attention entropy regulariser (temporal attention only)",
+    )
+    parser.add_argument(
+        "--attn-warmup-epochs",
+        type=int,
+        default=0,
+        help="Number of epochs to delay attention regularisation (temporal attention only)",
     )
     parser.add_argument(
         "--time_kernel",

--- a/tests/worldcerealtests/test_finetuning.py
+++ b/tests/worldcerealtests/test_finetuning.py
@@ -45,6 +45,7 @@ class TestFinetunePrestoEndToEnd(unittest.TestCase):
     ):
         train_dl = DataLoader(train_ds, batch_size=2, shuffle=True)
         val_dl = DataLoader(val_ds, batch_size=2, shuffle=False)
+        diag_dl = DataLoader(val_ds, batch_size=2, shuffle=False)
 
         model = build_worldcereal_presto(
             num_outputs=num_outputs,
@@ -63,6 +64,7 @@ class TestFinetunePrestoEndToEnd(unittest.TestCase):
             model,
             train_dl,
             val_dl,
+            diag_dl,
             experiment_name=f"{task_type}-test",
             output_dir=output_dir,
             task_type=task_type,
@@ -86,6 +88,7 @@ class TestFinetunePrestoEndToEnd(unittest.TestCase):
     ):
         train_dl = DataLoader(train_ds, batch_size=2, shuffle=True)
         val_dl = DataLoader(val_ds, batch_size=2, shuffle=False)
+        diag_dl = DataLoader(val_ds, batch_size=2, shuffle=False)
 
         model = build_worldcereal_presto(
             num_outputs=num_outputs,
@@ -104,6 +107,7 @@ class TestFinetunePrestoEndToEnd(unittest.TestCase):
             model=model,
             train_dl=train_dl,
             val_dl=val_dl,
+            diag_dl=diag_dl,
             experiment_name=f"{task_type}-temporal-test",
             output_dir=output_dir,
             task_type=task_type,
@@ -270,6 +274,7 @@ class TestFinetunePrestoEndToEndDekad(unittest.TestCase):
     ):
         train_dl = DataLoader(train_ds, batch_size=2, shuffle=True)
         val_dl = DataLoader(val_ds, batch_size=2, shuffle=False)
+        diag_dl = DataLoader(val_ds, batch_size=2, shuffle=False)
 
         model = build_worldcereal_presto(
             num_outputs=num_outputs,
@@ -287,6 +292,7 @@ class TestFinetunePrestoEndToEndDekad(unittest.TestCase):
             model,
             train_dl,
             val_dl,
+            diag_dl,
             experiment_name=f"{task_type}-test",
             output_dir=output_dir,
             task_type=task_type,


### PR DESCRIPTION
## Summary
- restructure the Presto finetuning head to emit per-timestep logits and keep temporal attention optional for diagnostics
- normalize temporal kernel weighting, add optional attention KL/entropy regularizers, and log localization diagnostics during training
- surface the new attention regularization knobs in the finetuning script, update documentation, and adapt tests to provide diagnostic loaders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d6a76d5e24832d82e4438b767d234c