### PR TITLE
Correct import of MIN_EDGE_BUFFER

### DIFF
--- a/notebooks/notebook_utils/classifier.py
+++ b/notebooks/notebook_utils/classifier.py
@@ -38,8 +38,8 @@ from sklearn.model_selection import train_test_split
 from sklearn.utils.class_weight import compute_class_weight
 
 from worldcereal.parameters import CropLandParameters, CropTypeParameters
+from worldcereal.train.datasets import MIN_EDGE_BUFFER
 from worldcereal.utils.refdata import process_extractions_df
-from worldcereal.utils.timeseries import MIN_EDGE_BUFFER
 
 
 def get_input(label):


### PR DESCRIPTION
In the recent PR, `MIN_EDGE_BUFFER` parameter got consolidated and imported from a cetralized place - the datasets module. 
One of the notebook utils was not rerouted properly, hence this PR.