### PR TITLE
Add human labels to training_df

### DIFF
--- a/src/worldcereal/utils/legend.py
+++ b/src/worldcereal/utils/legend.py
@@ -295,6 +295,7 @@ def translate_ewoc_codes(ewoc_codes: list[int]) -> pd.DataFrame:
         "level_3",
         "level_4",
         "level_5",
+        "sampling_label",
         "definition",
     ]
     legend = legend[columns_to_keep]
@@ -317,13 +318,17 @@ def translate_ewoc_codes(ewoc_codes: list[int]) -> pd.DataFrame:
     return legend
 
 
-def ewoc_code_to_label(ewoc_codes: list[int]) -> list[str]:
-    """Translate EWOC codes to their corresponding full label in the WorldCereal legend.
+def ewoc_code_to_label(
+    ewoc_codes: list[int], type: Literal["full", "sampling"] = "full"
+) -> list[str]:
+    """Translate EWOC codes to their corresponding full or sampling label in the WorldCereal legend.
 
     Parameters
     ----------
     ewoc_codes : list[int]
         List of EWOC codes to be translated.
+    type : Literal["full", "sampling"], optional
+        Type of label to return, by default "full"
 
     Returns
     -------
@@ -338,6 +343,9 @@ def ewoc_code_to_label(ewoc_codes: list[int]) -> list[str]:
         if code not in df.index:
             result.append("Unknown")
         else:
-            result.append(df.loc[code, "label_full"])
+            if type == "sampling":
+                result.append(df.loc[code, "sampling_label"])
+            else:
+                result.append(df.loc[code, "label_full"])
 
     return result

--- a/src/worldcereal/utils/refdata.py
+++ b/src/worldcereal/utils/refdata.py
@@ -587,6 +587,7 @@ def process_extractions_df(
     The function preserves the original 'valid_time' even when samples are aligned to a new temporal context.
     """
 
+    from worldcereal.utils.legend import ewoc_code_to_label
     from worldcereal.utils.timeseries import (
         DataFrameValidator,
         TimeSeriesProcessor,
@@ -696,6 +697,14 @@ def process_extractions_df(
         # put back the true valid_time
         df_processed["valid_time"] = df_processed.index.map(true_valid_time_map)
         df_processed["valid_time"] = df_processed["valid_time"].dt.strftime("%Y-%m-%d")
+
+    # Enrich resulting dataframe with full and sampling string labels
+    df_processed["label_full"] = ewoc_code_to_label(
+        df_processed["ewoc_code"], type="full"
+    )
+    df_processed["sampling_label"] = ewoc_code_to_label(
+        df_processed["ewoc_code"], type="sampling"
+    )
 
     logger.info(
         f"Extracted and processed {df_processed.shape[0]} samples from global database."

--- a/tests/worldcerealtests/test_pipelines.py
+++ b/tests/worldcerealtests/test_pipelines.py
@@ -82,7 +82,8 @@ def test_custom_croptype_demo(WorldCerealPrivateExtractionsPath):
     print("*" * 40)
 
     # Direct shape assert: if process_extractions_df changes, this may have to be updated
-    assert training_df.shape == (238, 245)
+    # adding 2 columns, since now we expect process_extractions_df to return label_full and sampling_labels
+    assert training_df.shape == (238, (245 + 2))
 
     # We keep original ewoc_code for this test
     training_df["downstream_class"] = training_df["ewoc_code"]


### PR DESCRIPTION
- Modified `legend` utilities to also give away `sampling_label` if needed (`label_full` can be too overwhelming)
- Enriched training_df to have both `label_full` and `sampling_label` during `process_extractions_df` execution
- Corrected relevant test case