### PR TITLE
Pin patch-to-point workflow to python 3.8 until it works on python 3.11

### DIFF
--- a/scripts/extractions/patch_to_point.py
+++ b/scripts/extractions/patch_to_point.py
@@ -270,7 +270,7 @@ if __name__ == "__main__":
         "--max_executors", type=int, default=None, help="Max executors."
     )
     parser.add_argument(
-        "--image_name", type=str, default=None, help="openEO image name."
+        "--image_name", type=str, default="python38", help="openEO image name."  # Use python 3.8 by default, until patch-to-point works on 3.11 https://github.com/eu-cdse/openeo-cdse-infra/issues/738
     )
     parser.add_argument(
         "--organization_id", type=int, default=None, help="Organization id."


### PR DESCRIPTION
https://github.com/eu-cdse/openeo-cdse-infra/issues/738

Patch-to-point fails on Python 3.11, which will soon become the default image on OpenEO. 

Devs are looking into a fix. Until then, we pin patch-to-point to Python 3.8 to ensure it keeps working. 