### PR TITLE
Exposing frequency argument in collect_inputs

### DIFF
--- a/scripts/inference/run_collect_inputs.py
+++ b/scripts/inference/run_collect_inputs.py
@@ -73,6 +73,7 @@ def create_worldcereal_inputsjob(
     connection_provider,
     s1_orbit_state: Optional[Literal["ASCENDING", "DESCENDING"]] = None,
     job_options: Optional[dict] = None,
+    compositing_window: Literal["month", "dekad"] = "month",
 ):
     """Function to create a job for collecting preprocessed inputs for WorldCereal.
     Parameters
@@ -104,6 +105,7 @@ def create_worldcereal_inputsjob(
         temporal_extent=temporal_extent,
         s1_orbit_state=s1_orbit_state,
         target_epsg=int(row["epsg"]),
+        compositing_window=compositing_window,
     )
 
     # If no custom job options are provided, use these defaults
@@ -246,6 +248,7 @@ def main(
     parallel_jobs: int = 2,
     restart_failed: bool = False,
     job_options: Optional[Dict[str, Union[str, int]]] = None,
+    compositing_window: Literal["month", "dekad"] = "month",
 ) -> None:
     """Main function responsible for creating and launching jobs to collect preprocessed inputs.
 
@@ -275,6 +278,8 @@ def main(
         Recognized keys:
             executor-memory, python-memory, max-executors, image-name, etl_organization_id.
             See worldcereal.utils.argparser.DEFAULT_JOB_OPTIONS for defaults.
+    compositing_window : Literal['month', 'dekad'], optional
+        The compositing window to use for the inputs, by default "month".
 
     Returns
     -------
@@ -322,6 +327,7 @@ def main(
                     s1_orbit_state=s1_orbit_state,
                     job_options=job_options,
                     connection=connection,
+                    compositing_window=compositing_window,
                 ),
                 job_db=job_db,
             )

--- a/src/worldcereal/job.py
+++ b/src/worldcereal/job.py
@@ -419,6 +419,7 @@ def create_inputs_process_graph(
     backend_context: BackendContext = BackendContext(Backend.CDSE),
     tile_size: Optional[int] = 128,
     target_epsg: Optional[int] = None,
+    compositing_window: Literal["month", "dekad"] = "month",
 ) -> openeo.DataCube:
     """Wrapper function that creates the inputs openEO process graph.
 
@@ -440,6 +441,9 @@ def create_inputs_process_graph(
     target_epsg: Optional[int] = None
         EPSG code to use for the output products. If not provided, the
         default EPSG will be used.
+    compositing_window: Literal["month", "dekad"]
+        Compositing window to use for the data loading in OpenEO, by default
+        "month".
 
     Returns
     -------
@@ -469,6 +473,7 @@ def create_inputs_process_graph(
         tile_size=tile_size,
         s1_orbit_state=s1_orbit_state,
         target_epsg=target_epsg,
+        compositing_window=compositing_window,
         # disable_meteo=True,
     )
 
@@ -484,6 +489,7 @@ def create_inputs_process_graph(
     )
 
     return inputs
+
 
 def create_inference_job(
     row: pd.Series,
@@ -962,9 +968,9 @@ def setup_inference_job_manager(
             "bounds_epsg",
         ]
         for attr in REQUIRED_ATTRIBUTES:
-            assert attr in production_gdf.columns, (
-                f"The production grid must contain a '{attr}' column."
-            )
+            assert (
+                attr in production_gdf.columns
+            ), f"The production grid must contain a '{attr}' column."
 
         job_df = production_gdf[REQUIRED_ATTRIBUTES].copy()
 


### PR DESCRIPTION
The argument was not previously exposed, thus making it impossible to collect dekadal inputs. This PR addresses that.