### PR TITLE
add explicit scikit-image dependency in udf_distance_to_cloud.py #462

### DIFF
--- a/src/worldcereal/openeo/udf_distance_to_cloud.py
+++ b/src/worldcereal/openeo/udf_distance_to_cloud.py
@@ -1,3 +1,9 @@
+# /// script
+# dependencies = [
+#   "scikit-image",
+# ]
+# ///
+
 import numpy as np
 import xarray as xr
 from openeo.udf import XarrayDataCube


### PR DESCRIPTION
The new openeo Python 3.11 image, which will become the default one at 28/10/2025 does not have the `scikit-image` dependency by default anymore. So the dependency has been added explicitly in the UDF, to make the UDF futureproof. 