### PR TITLE
Making on-disk-db robust to new columns

### DIFF
--- a/src/worldcereal/train/data.py
+++ b/src/worldcereal/train/data.py
@@ -153,6 +153,88 @@ def remove_small_classes(df, min_samples):
     return df
 
 
+def duckdb_type_from_series(s: pd.Series) -> str:
+    """
+    Infer a DuckDB column type from a pandas Series.
+    We'll be conservative:
+    - ints -> BIGINT
+    - floats -> DOUBLE
+    - bool -> BOOLEAN
+    - everything else -> TEXT
+    """
+    if pd.api.types.is_integer_dtype(s):
+        return "BIGINT"
+    if pd.api.types.is_float_dtype(s):
+        return "DOUBLE"
+    if pd.api.types.is_bool_dtype(s):
+        return "BOOLEAN"
+    # timestamps: let DuckDB infer TIMESTAMP if we detect datetime64
+    if pd.api.types.is_datetime64_any_dtype(s):
+        return "TIMESTAMP"
+    return "TEXT"
+
+
+def get_table_columns(con, table_name):
+    """Return current column names (ordered) from the DuckDB table."""
+    info_df = con.execute(f"PRAGMA table_info('{table_name}')").df()
+    return list(info_df["name"])
+
+
+def add_missing_columns_to_table(con, table_name, batch_df, current_cols, nodata_value):
+    """
+    For each column in batch_df that is NOT yet in table_name:
+    ALTER TABLE ... ADD COLUMN that_col <type> DEFAULT NODATAVALUE (or NULL).
+    If the column looks numeric/bool/datetime, we add that sql type.
+    If we add a numeric column with DEFAULT NODATAVALUE, older rows get the fill.
+    """
+
+    new_cols = [c for c in batch_df.columns if c not in current_cols]
+
+    for col in new_cols:
+        col_type = duckdb_type_from_series(batch_df[col])
+
+        # Decide default value depending on type.
+        # For numeric types we can use NODATAVALUE.
+        # For non-numeric types, use NULL default so we don't shove NODATAVALUE into text/timestamps.
+        if col_type in ("BIGINT", "DOUBLE"):
+            default_expr = str(nodata_value)
+        elif col_type == "BOOLEAN":
+            default_expr = "FALSE"
+        elif col_type == "TIMESTAMP":
+            default_expr = "NULL"
+        else:
+            default_expr = "NULL"
+
+        # Quote column name if it has weird chars like '-' :
+        quoted_col = f'"{col}"'
+
+        alter_sql = (
+            f"ALTER TABLE {table_name} "
+            f"ADD COLUMN {quoted_col} {col_type} DEFAULT {default_expr};"
+        )
+        con.execute(alter_sql)
+
+    # Return updated list of columns from the table after ALTERs
+    return get_table_columns(con, table_name)
+
+
+def align_batch_to_table_columns(batch_df, table_cols, nodata_value):
+    """
+    Ensure batch_df has exactly all columns in table_cols.
+    - Add missing cols with nodata_value (or NaN for non-numeric).
+    - Reorder to table_cols.
+    """
+
+    # Add any columns that exist in table_cols but not in batch_df
+    missing_for_batch = [c for c in table_cols if c not in batch_df.columns]
+    for col in missing_for_batch:
+        batch_df[col] = nodata_value
+
+    # Reorder columns to match table
+    batch_df = batch_df[table_cols]
+    return batch_df
+
+
 def get_training_dfs_from_parquet(
     parquet_files: Union[Union[Path, str], List[Union[Path, str]]],
     timestep_freq: Literal["month", "dekad"] = "month",
@@ -311,10 +393,30 @@ def get_training_dfs_from_parquet(
                 con.execute(f"CREATE TABLE {table_name} AS SELECT * FROM pivot_batch")
                 initialized = True
             else:
+                # Make sure next batch aligns with table schema:
+                # 1. Get current columns from table
+                table_cols = get_table_columns(con, table_name)
+                # 2. If batch has NEW columns, ALTER TABLE to add them w/ defaults
+                table_cols = add_missing_columns_to_table(
+                    con,
+                    table_name,
+                    _data_pivot,
+                    table_cols,
+                    NODATAVALUE,
+                )
+                # 3. Align batch df to table columns (add any columns the table has that batch doesn't)
+                _data_pivot = align_batch_to_table_columns(
+                    _data_pivot,
+                    table_cols,
+                    NODATAVALUE,
+                )
+                # 4. Register and insert
+                con.register("pivot_batch", _data_pivot)
                 con.execute(
                     f"INSERT INTO {table_name} BY NAME SELECT * FROM pivot_batch"
                 )
-            con.unregister("pivot_batch")
+                con.unregister("pivot_batch")
+
             # --- force flush to disk & keep WAL small ---
             con.execute(
                 "CHECKPOINT"
@@ -324,11 +426,13 @@ def get_training_dfs_from_parquet(
             gc.collect()
 
         # write a single Parquet file
-        con.execute(f"""
+        con.execute(
+            f"""
             COPY (SELECT * FROM {table_name})
             TO '{wide_parquet_output_path}'
             (FORMAT PARQUET, COMPRESSION SNAPPY)
-        """)
+        """
+        )
 
     # Load the merged Parquet
     df = pd.read_parquet(wide_parquet_output_path)


### PR DESCRIPTION
A few utilities were added to make data loading process robust to column differences between batches, that may arise due to different number of available timestamps for each dataset. The updated procedure does the following:
- initializes db with the first dataset that comes into processing
- for every following dataset, it compares the columns and their types, aligning the table and batch between each other and ensuring consistency
- finally safely inserts batch into db