### PR TITLE
Updating prometheo wheel version in inference

### DIFF
--- a/src/worldcereal/openeo/inference.py
+++ b/src/worldcereal/openeo/inference.py
@@ -42,7 +42,7 @@ except ImportError:
 _MODULE_CACHE_KEY = f"__model_cache_{__name__}"
 
 # Constants
-PROMETHEO_WHL_URL = "https://artifactory.vgt.vito.be/artifactory/auxdata-public/worldcereal/dependencies/prometheo-0.0.2-py3-none-any.whl"
+PROMETHEO_WHL_URL = "https://artifactory.vgt.vito.be/artifactory/auxdata-public/worldcereal/dependencies/prometheo-0.0.3-py3-none-any.whl"
 
 GFMAP_BAND_MAPPING = {
     "S2-L2A-B02": "B2",


### PR DESCRIPTION
For some reason, inference.py had older version of prometheo wheel. Need to update.