### PR TITLE
Added forced reindexing before trimming

### DIFF
--- a/src/worldcereal/utils/timeseries.py
+++ b/src/worldcereal/utils/timeseries.py
@@ -1128,6 +1128,7 @@ def process_parquet(
         df["valid_position_diff"] = df["timestamp_ind"] - df["valid_position"]
         df = processor.check_vt_closeness(df, min_edge_buffer, freq)
 
+    df = df.reset_index(drop=True)
     if max_timesteps_trim is not None:
         logger.info(
             f"Trimming to max_timesteps_trim={max_timesteps_trim} per sample prior to pivot."


### PR DESCRIPTION
For some incoming long parquets, there is a non-unique default index encountered, which made `_trim_timesteps` function through all the samples and behave wildly.
A quickfix has been added to `process_parquet` to avoid that.