### PR TITLE
update meteo composite STAC API URLs to newest versions #539

### DIFF
--- a/src/worldcereal/extract/patch_to_point_worldcereal.py
+++ b/src/worldcereal/extract/patch_to_point_worldcereal.py
@@ -32,8 +32,12 @@ STAC_ENDPOINT_S2 = (
     "https://stac.openeo.vito.be/collections/worldcereal_sentinel_2_patch_extractions"
 )
 
-STAC_ENDPOINT_METEO_TERRASCOPE = (
-    "https://stac.openeo.vito.be/collections/agera5_monthly_terrascope"
+STAC_ENDPOINT_MONTHLY_METEO = (
+    "https://stac.openeo.vito.be/collections/agera5_monthly_composite"
+)
+
+STAC_ENDPOINT_DEKADAL_METEO = (
+    "https://stac.openeo.vito.be/collections/agera5_dekadal_composite"
 )
 
 STAC_ENDPOINT_SLOPE_TERRASCOPE = (
@@ -633,14 +637,14 @@ def worldcereal_preprocessed_inputs_from_patches(
     if period == "month":
         # Load precomposited monthly meteo data
         meteo_raw = connection.load_stac(
-            url=STAC_ENDPOINT_METEO_TERRASCOPE,
+            url=STAC_ENDPOINT_MONTHLY_METEO,
             temporal_extent=[temporal_extent.start_date, temporal_extent.end_date],
             bands=["temperature-mean", "precipitation-flux"],
         )
     elif period == "dekad":
         # Load precomposited dekadal meteo data
         meteo_raw = connection.load_stac(
-            url="https://stac.openeo.vito.be/collections/agera5_dekad_terrascope",
+            url=STAC_ENDPOINT_DEKADAL_METEO,
             temporal_extent=[temporal_extent.start_date, temporal_extent.end_date],
             bands=["temperature-mean", "precipitation-flux"],
         )

--- a/src/worldcereal/openeo/preprocessing.py
+++ b/src/worldcereal/openeo/preprocessing.py
@@ -413,7 +413,7 @@ def precomposited_datacube_METEO(
     elif compositing_window == "dekad":
         # Load precomposited dekadal meteo data
         cube = connection.load_stac(
-            url="https://stac.openeo.vito.be/collections/agera5_dekad",
+            url="https://stac.openeo.vito.be/collections/agera5_dekadal_composite",
             temporal_extent=temporal_extent,
             bands=["precipitation-flux", "temperature-mean"],
         )

--- a/src/worldcereal/udp/worldcereal_crop_extent.json
+++ b/src/worldcereal/udp/worldcereal_crop_extent.json
@@ -696,7 +696,7 @@
         "temporal_extent": {
           "from_parameter": "temporal_extent"
         },
-        "url": "https://stac.openeo.vito.be/collections/agera5_monthly"
+        "url": "https://stac.openeo.vito.be/collections/agera5_monthly_composite"
       }
     },
     "renamelabels7": {

--- a/src/worldcereal/udp/worldcereal_crop_type.json
+++ b/src/worldcereal/udp/worldcereal_crop_type.json
@@ -696,7 +696,7 @@
         "temporal_extent": {
           "from_parameter": "temporal_extent"
         },
-        "url": "https://stac.openeo.vito.be/collections/agera5_monthly"
+        "url": "https://stac.openeo.vito.be/collections/agera5_monthly_composite"
       }
     },
     "renamelabels7": {

--- a/tests/worldcerealtests/testresources/preprocess_from_patches_graph.json
+++ b/tests/worldcerealtests/testresources/preprocess_from_patches_graph.json
@@ -589,7 +589,7 @@
                 "2020-01-01",
                 "2020-12-31"
             ],
-            "url": "https://stac.openeo.vito.be/collections/agera5_monthly_terrascope"
+            "url": "https://stac.openeo.vito.be/collections/agera5_monthly_composite"
         }
     },
     "resamplespatial1": {

--- a/tests/worldcerealtests/testresources/preprocess_from_patches_graph_no_s1.json
+++ b/tests/worldcerealtests/testresources/preprocess_from_patches_graph_no_s1.json
@@ -199,7 +199,7 @@
                 "2020-01-01",
                 "2020-12-31"
             ],
-            "url": "https://stac.openeo.vito.be/collections/agera5_monthly_terrascope"
+            "url": "https://stac.openeo.vito.be/collections/agera5_monthly_composite"
         }
     },
     "resamplespatial1": {


### PR DESCRIPTION
- All pipelines should now use the new STAC API URLs for monthly and dekadal meteo composites, which are auto-completed in an Airflow workflow every month
- APEx benchmarks were checked with these new URLs and all passed