### PR TITLE
suppress openeo job db warnings

### DIFF
--- a/notebooks/notebook_utils/extractions.py
+++ b/notebooks/notebook_utils/extractions.py
@@ -2,6 +2,7 @@ import logging
 import textwrap
 import time
 import urllib.request
+import warnings
 from pathlib import Path
 from typing import List, Optional, Union
 
@@ -234,15 +235,22 @@ def run_extractions_notebook(
     )
 
     try:
-        job_db = run_extractions(
-            collection=collection,
-            output_folder=output_folder,
-            samples_df_path=samples_df_path,
-            ref_id=ref_id,
-            extract_value=extract_value,
-            restart_failed=restart_failed,
-            status_callback=status_callback,
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="WKTReadingError is deprecated",
+                category=FutureWarning,
+                module=r"openeo\.extra\.job_management\._job_db",
+            )
+            job_db = run_extractions(
+                collection=collection,
+                output_folder=output_folder,
+                samples_df_path=samples_df_path,
+                ref_id=ref_id,
+                extract_value=extract_value,
+                restart_failed=restart_failed,
+                status_callback=status_callback,
+            )
     except KeyboardInterrupt:
         _log(break_msg)
         raise

--- a/notebooks/notebook_utils/extractions.py
+++ b/notebooks/notebook_utils/extractions.py
@@ -235,6 +235,8 @@ def run_extractions_notebook(
     )
 
     try:
+        # TODO: remove this warning filter once the underlying issue
+        # in openeo-python-client is resolved (WKTReadingError deprecation warning)
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",


### PR DESCRIPTION
During point extractions workflow, I was receiving the following warnings which were cluttering logs:

/home/jeroendegerickx/miniconda3/envs/worldcereal/lib/python3.11/site-packages/openeo/extra/job_management/_job_db.py:131: FutureWarning: WKTReadingError is deprecated and will be removed in a future version. Use ShapelyError instead (functions previously raising {name} will now raise a ShapelyError instead).