### PR TITLE
Dateslider fix

### DIFF
--- a/notebooks/notebook_utils/classification_app.py
+++ b/notebooks/notebook_utils/classification_app.py
@@ -38,7 +38,7 @@ from notebook_utils.classifier import (
     train_seasonal_torch_head,
 )
 from notebook_utils.croptypepicker import CropTypePicker, apply_croptypepicker_to_df
-from notebook_utils.dateslider import date_slider as season_slider
+from notebook_utils.dateslider import date_slider, season_slider
 from notebook_utils.extractions import (
     get_band_statistics,
     query_extractions,
@@ -1662,12 +1662,8 @@ class WorldCerealClassificationApp:
             layout=widgets.Layout(width="100%", overflow="auto")
         )
         season_slider_obj = None
-        start_d = datetime(2019, 7, 1)
-        end_d = datetime(2021, 6, 30)
         with season_slider_output:
-            season_slider_obj = season_slider(
-                year_selector=False, show_year=False, start_date=start_d, end_date=end_d
-            )
+            season_slider_obj = season_slider()
 
         season_id_input = widgets.Text(
             value="",
@@ -3890,7 +3886,7 @@ class WorldCerealClassificationApp:
         )
         season_slider_obj = None
         with season_slider_output:
-            season_slider_obj = season_slider()
+            season_slider_obj = date_slider()
         season_id_input = widgets.Text(
             value=self.season_id,
             description="Season ID:",

--- a/notebooks/notebook_utils/dateslider.py
+++ b/notebooks/notebook_utils/dateslider.py
@@ -387,12 +387,13 @@ class season_slider(date_slider):
         # Set the start and end dates for the slider
         # The slider will cover a period from June 2017 to June 2019
         start_date = pd.to_datetime(("2017-07-01"))
-        end_date = pd.to_datetime(("2019-05-01"))
+        end_date = pd.to_datetime(("2019-06-30"))
 
         # Call the parent class constructor
         super().__init__(
             start_date=start_date,
             end_date=end_date,
+            year_selector=False,
             show_year=False,
             display_interval=1,
             title="Select season:",

--- a/notebooks/notebook_utils/dateslider.py
+++ b/notebooks/notebook_utils/dateslider.py
@@ -168,7 +168,15 @@ class date_slider:
         end_date: datetime,
         focus_year: Optional[int] = None,
     ) -> widgets.VBox:
-        dates = pd.date_range(start_date, end_date, freq="MS")
+        # Extend by one extra month so the end handle uses an exclusive-end
+        # convention: handle at month M means the season ends on the last day
+        # of month M-1. This makes the end handle sit visually one step past
+        # the last included month, matching user intuition.
+        dates = pd.date_range(
+            start_date,
+            pd.to_datetime(end_date) + pd.DateOffset(months=1),
+            freq="MS",
+        )
         # Always use year-qualified labels to guarantee uniqueness.
         # Duplicate labels cause an infinite internal loop in ipywidgets
         # (_propagate_label ↔ _propagate_index) when the same month name
@@ -182,8 +190,9 @@ class date_slider:
                 if date.year == focus_year:
                     default_start_index = idx
                     break
+        # End index is exclusive: default_window_months steps past start
         default_end_index = min(
-            len(dates) - 1, default_start_index + self.default_window_months - 1
+            len(dates) - 1, default_start_index + self.default_window_months
         )
 
         self.interval_slider = widgets.SelectionRangeSlider(
@@ -216,16 +225,23 @@ class date_slider:
             tick_labels = [date.strftime("%b %Y") for date in tick_dates]
         else:
             tick_labels = [date.strftime("%b") for date in tick_dates]
-        n_labels = max(1, len(tick_labels))
+        # Total number of monthly steps in the slider (n options → n-1 intervals)
+        # dates now has one extra month appended for the exclusive end handle.
+        n_slider_steps = max(1, len(dates) - 1)
+        slider_start = dates[0]
         ticks_html = ""
-        for i, label in enumerate(tick_labels):
-            position = 0 if n_labels == 1 else (i / (n_labels - 1)) * 100
+        for date, label in zip(tick_dates, tick_labels):
+            # Position each tick by its distance from slider start, in months
+            months_from_start = (date.year - slider_start.year) * 12 + (
+                date.month - slider_start.month
+            )
+            position = min(100.0, (months_from_start / n_slider_steps) * 100)
             parts = label.split(" ") if " " in label else [label, ""]
             top_label = parts[0]
             bottom_label = parts[1] if len(parts) > 1 else ""
             ticks_html += f"""
-            <div class="tick-mark" style="left: {position}%; ">|</div>
-            <div class="tick-label" style="left: {position}%; ">{top_label}<br>{bottom_label}</div>
+            <div class="tick-mark" style="left: {position:.4f}%; ">|</div>
+            <div class="tick-label" style="left: {position:.4f}%; ">{top_label}<br>{bottom_label}</div>
             """
 
         tick_marks_and_labels = widgets.HTML(
@@ -268,19 +284,20 @@ class date_slider:
 
     def on_slider_change(self, change):
         start, end = change["new"]
+        # With exclusive-end, the number of selected months = steps between handles
         months_selected = self._get_month_span(start, end)
         n_opts = len(self.interval_slider.options)
         start_idx, end_idx = self.interval_slider.index
 
         clamped_index = None
         if months_selected > self.max_window_months:
-            new_end_idx = min(n_opts - 1, start_idx + self.max_window_months - 1)
+            new_end_idx = min(n_opts - 1, start_idx + self.max_window_months)
             clamped_index = (start_idx, new_end_idx)
         elif months_selected < self.min_window_months:
-            new_end_idx = start_idx + self.min_window_months - 1
+            new_end_idx = start_idx + self.min_window_months
             if new_end_idx >= n_opts:
                 new_end_idx = n_opts - 1
-                new_start_idx = max(0, new_end_idx - self.min_window_months + 1)
+                new_start_idx = max(0, new_end_idx - self.min_window_months)
                 clamped_index = (new_start_idx, new_end_idx)
             else:
                 clamped_index = (start_idx, new_end_idx)
@@ -321,7 +338,8 @@ class date_slider:
 
     def _update_summary(self, start: pd.Timestamp, end: pd.Timestamp):
         season_start = start.replace(day=1)
-        season_end = self._get_last_day_of_month(end)
+        # end is exclusive: the season ends on the last day of the previous month
+        season_end = self._get_last_day_of_month(end - pd.DateOffset(months=1))
 
         processing_start_month = season_end.replace(day=1) - pd.DateOffset(
             months=self.processing_months - 1
@@ -372,7 +390,8 @@ class date_slider:
 
     @staticmethod
     def _get_month_span(start: pd.Timestamp, end: pd.Timestamp) -> int:
-        months = (end.year - start.year) * 12 + (end.month - start.month) + 1
+        # end is exclusive, so span = number of steps between handles
+        months = (end.year - start.year) * 12 + (end.month - start.month)
         return max(1, months)
 
 

--- a/notebooks/notebook_utils/dateslider.py
+++ b/notebooks/notebook_utils/dateslider.py
@@ -169,10 +169,12 @@ class date_slider:
         focus_year: Optional[int] = None,
     ) -> widgets.VBox:
         dates = pd.date_range(start_date, end_date, freq="MS")
-        if self.show_year:
-            options = [(date.strftime("%b %Y"), date) for date in dates]
-        else:
-            options = [(date.strftime("%b"), date) for date in dates]
+        # Always use year-qualified labels to guarantee uniqueness.
+        # Duplicate labels cause an infinite internal loop in ipywidgets
+        # (_propagate_label ↔ _propagate_index) when the same month name
+        # appears more than once across years. The labels are never shown
+        # to the user (readout=False) — the visual tick marks are separate HTML.
+        options = [(date.strftime("%b %Y"), date) for date in dates]
 
         default_start_index = 0
         if focus_year is not None:

--- a/notebooks/notebook_utils/dateslider.py
+++ b/notebooks/notebook_utils/dateslider.py
@@ -269,13 +269,31 @@ class date_slider:
     def on_slider_change(self, change):
         start, end = change["new"]
         months_selected = self._get_month_span(start, end)
+        n_opts = len(self.interval_slider.options)
+        start_idx, end_idx = self.interval_slider.index
+
+        clamped_index = None
         if months_selected > self.max_window_months:
-            clamped_end = start + pd.DateOffset(months=self.max_window_months - 1)
-            self.interval_slider.value = (start, clamped_end)
-            return
-        if months_selected < self.min_window_months:
-            clamped_end = start + pd.DateOffset(months=self.min_window_months - 1)
-            self.interval_slider.value = (start, clamped_end)
+            new_end_idx = min(n_opts - 1, start_idx + self.max_window_months - 1)
+            clamped_index = (start_idx, new_end_idx)
+        elif months_selected < self.min_window_months:
+            new_end_idx = start_idx + self.min_window_months - 1
+            if new_end_idx >= n_opts:
+                new_end_idx = n_opts - 1
+                new_start_idx = max(0, new_end_idx - self.min_window_months + 1)
+                clamped_index = (new_start_idx, new_end_idx)
+            else:
+                clamped_index = (start_idx, new_end_idx)
+
+        if clamped_index is not None:
+            self.interval_slider.unobserve(self.on_slider_change, names="value")
+            try:
+                self.interval_slider.index = clamped_index
+                clamped_start = self.interval_slider.value[0]
+                clamped_end = self.interval_slider.value[1]
+                self._update_summary(clamped_start, clamped_end)
+            finally:
+                self.interval_slider.observe(self.on_slider_change, names="value")
             return
 
         self._update_summary(start, end)


### PR DESCRIPTION
This PR fixes several issues with date slider:
- season_slider showed weird behaviour when shifting the slider around. This had to do with internal date labels that were not unique.
- the slider position is now nicely aligned with the tick labels
- the end date is now more intuitive: if processing window runs to end of June, the slider is positioned on "Jul" tick mark
- the classification app now correctly imports season_slider in tab 3 and date_slider in tab 8