### PR TITLE
Bugfix: list of attributes that can be partially None needs to be updated

### DIFF
--- a/src/worldcereal/train/data.py
+++ b/src/worldcereal/train/data.py
@@ -35,8 +35,10 @@ _ATTR_KEYS_ALLOW_PARTIAL_NONE = {
     "landcover_label",
     "croptype_label",
     "label_task",
-    "anomaly_flag",
-    "confidence_nonoutlier",
+    "LC10_confidence_nonoutlier",
+    "CTY24_confidence_nonoutlier",
+    "LC10_anomaly_flag",
+    "CTY24_anomaly_flag",
 }
 
 _BOUNDARIES_PATH = (


### PR DESCRIPTION
We have to update `_ATTR_KEYS_ALLOW_PARTIAL_NONE` for the new attribute names of outlier scores so we allow them to be None in the collate function.