### PR TITLE
fix: correct CTY25 -> CTY24 column names and fix OPTIONAL_COLS types

### DIFF
--- a/src/worldcereal/train/data.py
+++ b/src/worldcereal/train/data.py
@@ -1024,10 +1024,10 @@ def get_training_dfs_from_parquet(
 
     # Columns that may not exist in older data — fill with sensible defaults
     OPTIONAL_COLS: dict = {
-        "CTY25_confidence_nonoutlier": "1.0",  # no outlier penalty
-        "LC10_confidence_nonoutlier": "1.0",
-        "CTY25_anomaly_flag": 0.0,  # not flagged
-        "LC10_anomaly_flag": 0.0,
+        "CTY24_confidence_nonoutlier": 1.0,  # no outlier penalty (float, not string)
+        "LC10_confidence_nonoutlier": 1.0,
+        "CTY24_anomaly_flag": "normal",  # string category, not a number
+        "LC10_anomaly_flag": "normal",
     }
 
     if overwrite or is_tempfile or not wide_parquet_output_path.exists():


### PR DESCRIPTION
**Bug:** Two wrong column names (`CTY25_confidence_nonoutlier, CT25_confidence_nonoutlier`) did not match the actual parquet schema column `CTY24_confidence_nonoutlier`. Also fixed two type errors in `OPTIONAL_COLS` (string "1.0" → float 1.0; numeric 0.0 → string "normal" for anomaly flags).

**Impact**: With the wrong column name, `_series_from_column `silently fell back to weight=1.0 for every CT sample, meaning CTY24 outlier confidence scores were completely ignored during training. After this, CT samples are correctly down-weighted by their actual outlier confidence. 

The `OPTIONAL_COLS `fix applies to the long-parquet rebuild path and is pushed in this repo. The current training path using `--wide_parquet_path` is affected by this `finetune_presto.py` fix in worldcereal-finetune repo. 