### PR TITLE
Several fixes for outlier (score) handling

### DIFF
--- a/notebooks/notebook_utils/classifier.py
+++ b/notebooks/notebook_utils/classifier.py
@@ -380,7 +380,7 @@ def train_seasonal_torch_head(
         quality_col=quality_col,
         outlier_score_col=outlier_score_col,
         outlier_col=outlier_col,
-        outlier_drop_level="drop_candidate",
+        outlier_drop_mode="drop_candidate",
         zero_quality_cols=zero_quality_cols,
         **trainer_kwargs,
     )

--- a/notebooks/notebook_utils/classifier.py
+++ b/notebooks/notebook_utils/classifier.py
@@ -22,6 +22,7 @@ from openeo_gfmap import TemporalContext
 from prometheo.utils import DEFAULT_SEED
 from tabulate import tabulate
 
+from worldcereal.train import OUTLIER_COLUMNS
 from worldcereal.train.backbone import (
     build_presto_backbone,
     checkpoint_fingerprint,
@@ -360,13 +361,13 @@ def train_seasonal_torch_head(
     # Quality and outlier columns
     if head_task == "croptype":
         quality_col = "quality_score_ct"
-        outlier_score_col = "CTY24_confidence_nonoutlier"
-        outlier_col = "CTY24_anomaly_flag"
+        outlier_score_col = OUTLIER_COLUMNS["CT_outlier_score"]
+        outlier_col = OUTLIER_COLUMNS["CT_outlier_flag"]
         zero_quality_cols = ["quality_score_lc", "quality_score_ct"]
     else:
         quality_col = "quality_score_lc"
-        outlier_score_col = "LC10_confidence_nonoutlier"
-        outlier_col = "LC10_anomaly_flag"
+        outlier_score_col = OUTLIER_COLUMNS["LC_outlier_score"]
+        outlier_col = OUTLIER_COLUMNS["LC_outlier_flag"]
         zero_quality_cols = ["quality_score_lc"]
 
     trainer = TorchTrainer(

--- a/src/worldcereal/train/__init__.py
+++ b/src/worldcereal/train/__init__.py
@@ -9,6 +9,13 @@ MIN_EDGE_BUFFER = 2
 
 GLOBAL_SEASON_IDS: Tuple[str, ...] = ("tc-s1", "tc-s2")
 
+OUTLIER_COLUMNS: dict = {
+    "CT_outlier_score": "CTY24_confidence_nonoutlier",
+    "LC_outlier_score": "LC10_confidence_nonoutlier",
+    "CT_outlier_flag": "CTY24_anomaly_flag",
+    "LC_outlier_flag": "LC10_anomaly_flag",
+}
+
 SEASONALITY_LOOKUP_FILENAME = "seasonality_lookup.parquet"
 SEASONALITY_LOOKUP_PACKAGE = "worldcereal.data.cropcalendars"
 SEASONALITY_LOOKUP_PATH = (
@@ -33,6 +40,7 @@ SEASONALITY_LON_RANGE = (-179.999, 179.999)
 
 __all__ = [
     "GLOBAL_SEASON_IDS",
+    "OUTLIER_COLUMNS",
     "MIN_EDGE_BUFFER",
     "SEASONALITY_LOOKUP_FILENAME",
     "SEASONALITY_LOOKUP_PACKAGE",

--- a/src/worldcereal/train/data.py
+++ b/src/worldcereal/train/data.py
@@ -17,6 +17,7 @@ from sklearn.model_selection import train_test_split
 from torch.utils.data import DataLoader, default_collate
 from tqdm import tqdm
 
+from worldcereal.train import OUTLIER_COLUMNS
 from worldcereal.train.backbone import build_presto_backbone, resolve_seasonal_encoder
 from worldcereal.train.datasets import (
     SeasonCalendarMode,
@@ -999,8 +1000,6 @@ def get_training_dfs_from_parquet(
     ]
     INT_COLS = [
         "extract",
-        "quality_score_ct",
-        "quality_score_lc",
         "ewoc_code",
         "S2-L2A-B02",
         "S2-L2A-B03",
@@ -1019,15 +1018,24 @@ def get_training_dfs_from_parquet(
         "AGERA5-PRECIP",
         "AGERA5-TMEAN",
     ]
-    FLOAT_COLS = ["lon", "lat"]
+    FLOAT_COLS = [
+        "lon",
+        "lat",
+        "quality_score_ct",
+        "quality_score_lc",
+    ]
     REQUIRED_COLS = STRING_COLS + INT_COLS + FLOAT_COLS
 
     # Columns that may not exist in older data — fill with sensible defaults
     OPTIONAL_COLS: dict = {
-        "CTY25_confidence_nonoutlier": "1.0",  # no outlier penalty
-        "LC10_confidence_nonoutlier": "1.0",
-        "CTY25_anomaly_flag": 0.0,  # not flagged
-        "LC10_anomaly_flag": 0.0,
+        OUTLIER_COLUMNS[
+            "CT_outlier_score"
+        ]: 1.0,  # no outlier penalty (float, not string)
+        OUTLIER_COLUMNS[
+            "LC_outlier_score"
+        ]: 1.0,  # no outlier penalty (float, not string)
+        OUTLIER_COLUMNS["CT_outlier_flag"]: "normal",  # string category, not a number
+        OUTLIER_COLUMNS["LC_outlier_flag"]: "normal",  # string category, not a number
     }
 
     if overwrite or is_tempfile or not wide_parquet_output_path.exists():

--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -36,6 +36,7 @@ from worldcereal.seasons import season_doys_to_dates_refyear
 from worldcereal.train import (
     GLOBAL_SEASON_IDS,
     MIN_EDGE_BUFFER,
+    OUTLIER_COLUMNS,
     SEASONALITY_COLUMN_MAP,
     SEASONALITY_LAT_RANGE,
     SEASONALITY_LON_RANGE,
@@ -100,11 +101,9 @@ SAMPLE_ATTR_COLUMNS: Tuple[str, ...] = (
     "quality_score_ct",
     "sample_weight_lc",
     "sample_weight_ct",
-    "LC10_confidence_nonoutlier",
-    "CTY24_confidence_nonoutlier",
-    "LC10_anomaly_flag",
-    "CTY24_anomaly_flag",
+    *OUTLIER_COLUMNS.values(),
 )
+
 
 _LABEL_DATETIME_COLUMNS: Tuple[str, ...] = (
     "valid_time",

--- a/src/worldcereal/train/downstream.py
+++ b/src/worldcereal/train/downstream.py
@@ -37,7 +37,6 @@ from worldcereal.train.data import spatial_train_val_test_split, train_val_test_
 from worldcereal.train.datasets import get_class_weights
 from worldcereal.train.finetuning_utils import (
     attach_sample_weights,
-    drop_outliers,
     drop_zero_quality_samples,
     filter_low_weight_eval_samples,
     patch_lc_dataset_ct_quality,
@@ -116,9 +115,9 @@ class TorchTrainer:
         quality_col: Optional[str] = None,
         outlier_score_col: Optional[str] = None,
         outlier_col: Optional[str] = None,
-        outlier_drop_level: Optional[
-            Literal["drop_candidate", "drop_suspect", "drop_flagged"]
-        ] = None,
+        outlier_drop_mode: Literal[
+            "keep", "drop_candidate", "drop_suspect", "drop_flagged"
+        ] = "keep",
         zero_quality_cols: Optional[Sequence[str]] = None,
         eval_weight_floor: Optional[float] = 0.5,
         eval_weight_percentile: float = 20.0,
@@ -196,7 +195,7 @@ class TorchTrainer:
 
         # Sample filtering
         self.outlier_col = outlier_col
-        self.outlier_drop_level = outlier_drop_level
+        self.outlier_drop_mode = outlier_drop_mode
         self.zero_quality_cols = list(zero_quality_cols) if zero_quality_cols else []
 
         # Eval quality filtering
@@ -247,7 +246,7 @@ class TorchTrainer:
                 "quality_col": self.quality_col,
                 "outlier_score_col": self.outlier_score_col,
                 "outlier_col": self.outlier_col,
-                "outlier_drop_level": self.outlier_drop_level,
+                "outlier_drop_mode": self.outlier_drop_mode,
                 "zero_quality_cols": self.zero_quality_cols,
                 "eval_weight_floor": self.eval_weight_floor,
                 "eval_weight_percentile": self.eval_weight_percentile,
@@ -685,27 +684,6 @@ class TorchTrainer:
         val_df = self._drop_invalid_samples(val_df)
         test_df = self._drop_invalid_samples(test_df)
 
-        # Optionally drop flagged outlier samples
-        if self.outlier_col and self.outlier_drop_level:
-            train_df = drop_outliers(
-                train_df,
-                "train",
-                outlier_col=self.outlier_col,
-                drop_level=self.outlier_drop_level,
-            )
-            val_df = drop_outliers(
-                val_df,
-                "val",
-                outlier_col=self.outlier_col,
-                drop_level=self.outlier_drop_level,
-            )
-            test_df = drop_outliers(
-                test_df,
-                "test",
-                outlier_col=self.outlier_col,
-                drop_level=self.outlier_drop_level,
-            )
-
         # Optionally drop samples where all quality scores are zero
         if self.zero_quality_cols:
             train_df = drop_zero_quality_samples(
@@ -732,6 +710,8 @@ class TorchTrainer:
             "train",
             quality_score_col=self.quality_col or "",
             outlier_score_col=self.outlier_score_col or "",
+            outlier_flag_col=self.outlier_col or "",
+            outlier_drop_mode=self.outlier_drop_mode or "keep",
             output_col="_sample_weight",
         )
         val_df = attach_sample_weights(
@@ -739,6 +719,8 @@ class TorchTrainer:
             "val",
             quality_score_col=self.quality_col or "",
             outlier_score_col=self.outlier_score_col or "",
+            outlier_flag_col=self.outlier_col or "",
+            outlier_drop_mode=self.outlier_drop_mode or "keep",
             output_col="_sample_weight",
         )
         test_df = attach_sample_weights(
@@ -746,6 +728,8 @@ class TorchTrainer:
             "test",
             quality_score_col=self.quality_col or "",
             outlier_score_col=self.outlier_score_col or "",
+            outlier_flag_col=self.outlier_col or "",
+            outlier_drop_mode=self.outlier_drop_mode or "keep",
             output_col="_sample_weight",
         )
 

--- a/src/worldcereal/train/finetuning_utils.py
+++ b/src/worldcereal/train/finetuning_utils.py
@@ -37,6 +37,7 @@ except ImportError:  # pragma: no cover
     SummaryWriter = None  # type: ignore[misc,assignment]
 from tqdm.auto import tqdm
 
+from worldcereal.train import OUTLIER_COLUMNS
 from worldcereal.train.data import collate_fn
 from worldcereal.train.datasets import (
     SensorMaskingConfig,
@@ -138,7 +139,7 @@ def patch_lc_dataset_ct_quality(df: pd.DataFrame) -> pd.DataFrame:
 def drop_outliers(
     df: pd.DataFrame,
     split_name: str,
-    outlier_col: str = "LC10_anomaly_flag",
+    outlier_col: str = OUTLIER_COLUMNS["LC_outlier_flag"],
     drop_level: Literal[
         "drop_candidate", "drop_suspect", "drop_flagged"
     ] = "drop_candidate",

--- a/src/worldcereal/train/finetuning_utils.py
+++ b/src/worldcereal/train/finetuning_utils.py
@@ -235,15 +235,15 @@ def identify_true_outliers(
     pd.Series
         Boolean Series with ``False`` for non-outlier samples and ``True`` for outliers.
     """
-    if outlier_col not in df.columns:
-        logger.warning(
-            f"Outlier drop requested but '{outlier_col}' column is missing in {split_name} split."
-        )
-        return pd.Series(False, index=df.index, dtype=bool)
-
     if drop_level == "keep":
         logger.info(
             f"Outlier drop mode set to 'keep'; no samples will be treated as outliers in {split_name} split."
+        )
+        return pd.Series(False, index=df.index, dtype=bool)
+
+    if outlier_col not in df.columns:
+        logger.warning(
+            f"Outlier drop requested but '{outlier_col}' column is missing in {split_name} split."
         )
         return pd.Series(False, index=df.index, dtype=bool)
 

--- a/src/worldcereal/train/finetuning_utils.py
+++ b/src/worldcereal/train/finetuning_utils.py
@@ -80,16 +80,68 @@ def attach_sample_weights(
     split_name: str,
     quality_score_col: str,
     outlier_score_col: str,
+    outlier_flag_col: str,
+    outlier_drop_mode: Literal["drop_candidate", "drop_suspect", "drop_flagged"],
     output_col: str,
 ) -> pd.DataFrame:
-    """Compute per-sample weight as the product of quality and outlier scores.
+    """Compute and attach a per-sample weight column to *df*.
 
-    Each score independently modulates the sample weight:
-    score=1 means no effect, score<1 means proportional down-weighting.
+    The final weight is the element-wise product of three independent factors,
+    each in ``[0, 1]``, clipped to that range after multiplication:
+
+        weight = quality_score × outlier_score × outlier_flag_mask
+
+    **quality_score** – read from *quality_score_col*; reflects annotation
+    confidence.  Scores on the 0–100 integer scale are automatically
+    rescaled to ``[0, 1]``.  Missing column → defaults to 1.0 (no effect).
+
+    **outlier_score** – read from *outlier_flag_col*; a continuous confidence
+    score produced by the outlier-detection pipeline.  Same scale handling as
+    quality_score.  Missing column → defaults to 1.0.
+
+    **outlier_flag_mask** – a hard binary gate derived from *outlier_flag_col*
+    and *outlier_drop_mode* via :func:`identify_true_outliers`.  Samples
+    whose flag exceeds the chosen severity threshold receive 0; all others
+    receive 1.  Missing column → all samples treated as clean (mask = 1).
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input split DataFrame.  Must contain a ``sample_id`` column when
+        *outlier_flag_col* is present.
+    split_name : str
+        Human-readable name of the split (e.g. ``"train"``, ``"val"``);
+        used only for log messages.
+    quality_score_col : str
+        Column holding the annotation quality score.  Pass an absent name to
+        disable quality-based down-weighting.
+    outlier_score_col : str
+        Column holding the continuous outlier confidence score.  Pass an
+        absent name to disable score-based down-weighting.
+    outlier_flag_col : str
+        Column holding categorical outlier flags (e.g.
+        ``"normal"``, ``"candidate"``, ``"suspect"``, ``"flagged"``).
+        Pass an absent name to disable hard outlier gating.
+    outlier_drop_mode : str
+        Severity threshold forwarded to :func:`identify_true_outliers`.
+        One of ``"drop_candidate"``, ``"drop_suspect"``, or
+        ``"drop_flagged"``.
+    output_col : str
+        Name of the new weight column written to the returned DataFrame.
+
+    Returns
+    -------
+    pd.DataFrame
+        A copy of *df* with *output_col* added.  The original DataFrame is
+        never modified in-place.  Weight stats (min / max / mean) are logged
+        at ``INFO`` level.
     """
     quality = _normalize_score(_series_from_column(df, quality_score_col, default=1.0))
     outlier = _normalize_score(_series_from_column(df, outlier_score_col, default=1.0))
-    combined = (quality * outlier).clip(0.0, 1.0)
+    zero_outlier_weights = (
+        ~identify_true_outliers(df, split_name, outlier_flag_col, outlier_drop_mode)
+    ).astype(float)  # Invert to get 1 for non-outliers, 0 for outliers
+    combined = (quality * outlier * zero_outlier_weights).clip(0.0, 1.0)
 
     updated = df.copy()
     updated[output_col] = combined
@@ -136,27 +188,41 @@ def patch_lc_dataset_ct_quality(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def drop_outliers(
+def identify_true_outliers(
     df: pd.DataFrame,
     split_name: str,
     outlier_col: str = OUTLIER_COLUMNS["LC_outlier_flag"],
     drop_level: Literal[
         "drop_candidate", "drop_suspect", "drop_flagged"
     ] = "drop_candidate",
-) -> pd.DataFrame:
-    """Drop samples flagged as outliers from a split dataframe.
+) -> pd.Series:
+    """Identify samples flagged as outliers from a split dataframe.
 
-    The *drop_level* controls which flag values are considered outliers:
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe containing sample records.
+    split_name : str
+        Name of the split (e.g., 'train', 'val', 'test') for logging purposes.
+    outlier_col : str, optional
+        Column name containing outlier flags. Default is the LC outlier column.
+    drop_level : {'drop_candidate', 'drop_suspect', 'drop_flagged'}
+        Controls which flag values are considered outliers:
 
-    - ``"drop_candidate"`` – only samples labelled ``"candidate"``.
-    - ``"drop_suspect"``   – samples labelled ``"candidate"`` or ``"suspect"``.
-    - ``"drop_flagged"``   – all of the above plus ``"flagged"``.
+        - ``'drop_candidate'`` – only samples labelled ``'candidate'``.
+        - ``'drop_suspect'`` – samples labelled ``'candidate'`` or ``'suspect'``.
+        - ``'drop_flagged'`` – all of the above plus ``'flagged'``.
+
+    Returns
+    -------
+    pd.Series
+        Boolean Series with ``False`` for non-outlier samples and ``True`` for outliers.
     """
     if outlier_col not in df.columns:
         logger.warning(
             f"Outlier drop requested but '{outlier_col}' column is missing in {split_name} split."
         )
-        return df
+        return pd.Series(False, index=df.index, dtype=bool)
 
     if drop_level == "drop_candidate":
         outliers = df[df[outlier_col] == "candidate"]["sample_id"].tolist()
@@ -175,15 +241,14 @@ def drop_outliers(
 
     if len(outliers) > 0:
         logger.warning(
-            f"Dropping {len(outliers)} samples from {split_name} split "
+            f"Identified {len(outliers)} samples from {split_name} split "
             f"with outlier categories <= '{drop_level}'"
         )
-        df = df[~df["sample_id"].isin(outliers)].copy()
     else:
         logger.info(
-            f"No samples dropped from {split_name} split for outlier level '{drop_level}'."
+            f"No samples identified from {split_name} split for outlier level '{drop_level}'."
         )
-    return df
+    return df["sample_id"].isin(outliers)
 
 
 def drop_zero_quality_samples(

--- a/src/worldcereal/train/finetuning_utils.py
+++ b/src/worldcereal/train/finetuning_utils.py
@@ -81,7 +81,9 @@ def attach_sample_weights(
     quality_score_col: str,
     outlier_score_col: str,
     outlier_flag_col: str,
-    outlier_drop_mode: Literal["drop_candidate", "drop_suspect", "drop_flagged"],
+    outlier_drop_mode: Literal[
+        "keep", "drop_candidate", "drop_suspect", "drop_flagged"
+    ],
     output_col: str,
 ) -> pd.DataFrame:
     """Compute and attach a per-sample weight column to *df*.
@@ -124,7 +126,7 @@ def attach_sample_weights(
         Pass an absent name to disable hard outlier gating.
     outlier_drop_mode : str
         Severity threshold forwarded to :func:`identify_true_outliers`.
-        One of ``"drop_candidate"``, ``"drop_suspect"``, or
+        One of ``"keep"``, ``"drop_candidate"``, ``"drop_suspect"``, or
         ``"drop_flagged"``.
     output_col : str
         Name of the new weight column written to the returned DataFrame.
@@ -193,7 +195,7 @@ def identify_true_outliers(
     split_name: str,
     outlier_col: str = OUTLIER_COLUMNS["LC_outlier_flag"],
     drop_level: Literal[
-        "drop_candidate", "drop_suspect", "drop_flagged"
+        "keep", "drop_candidate", "drop_suspect", "drop_flagged"
     ] = "drop_candidate",
 ) -> pd.Series:
     """Identify samples flagged as outliers from a split dataframe.
@@ -206,9 +208,10 @@ def identify_true_outliers(
         Name of the split (e.g., 'train', 'val', 'test') for logging purposes.
     outlier_col : str, optional
         Column name containing outlier flags. Default is the LC outlier column.
-    drop_level : {'drop_candidate', 'drop_suspect', 'drop_flagged'}
+    drop_level : {'keep', 'drop_candidate', 'drop_suspect', 'drop_flagged'}
         Controls which flag values are considered outliers:
 
+        - ``'keep'`` – no samples are considered outliers.
         - ``'drop_candidate'`` – only samples labelled ``'candidate'``.
         - ``'drop_suspect'`` – samples labelled ``'candidate'`` or ``'suspect'``.
         - ``'drop_flagged'`` – all of the above plus ``'flagged'``.
@@ -221,6 +224,12 @@ def identify_true_outliers(
     if outlier_col not in df.columns:
         logger.warning(
             f"Outlier drop requested but '{outlier_col}' column is missing in {split_name} split."
+        )
+        return pd.Series(False, index=df.index, dtype=bool)
+
+    if drop_level == "keep":
+        logger.info(
+            f"Outlier drop mode set to 'keep'; no samples will be treated as outliers in {split_name} split."
         )
         return pd.Series(False, index=df.index, dtype=bool)
 

--- a/src/worldcereal/train/finetuning_utils.py
+++ b/src/worldcereal/train/finetuning_utils.py
@@ -148,11 +148,25 @@ def attach_sample_weights(
     updated = df.copy()
     updated[output_col] = combined
 
+    # Log percentage of zero weights and stats on non-zero weights
+    zero_mask = combined == 0.0
+    pct_zero = 100 * zero_mask.sum() / len(combined)
+    non_zero = combined[~zero_mask]
+
+    if len(non_zero) == 0:
+        raise ValueError(
+            f"{split_name}: all sample weights are 0.0 for {output_col}. "
+            "Cannot proceed with training - check quality scores, outlier scores, "
+            "and outlier drop settings."
+        )
+
     stats = {
-        "min": float(combined.min()),
-        "max": float(combined.max()),
-        "mean": float(combined.mean()),
+        "pct_zero": f"{pct_zero:.1f}%",
+        "non_zero_min": float(non_zero.min()),
+        "non_zero_max": float(non_zero.max()),
+        "non_zero_mean": float(non_zero.mean()),
     }
+
     logger.info(f"{split_name} {output_col} stats: {stats}")
     return updated
 

--- a/src/worldcereal/train/finetuning_utils.py
+++ b/src/worldcereal/train/finetuning_utils.py
@@ -97,7 +97,7 @@ def attach_sample_weights(
     confidence.  Scores on the 0–100 integer scale are automatically
     rescaled to ``[0, 1]``.  Missing column → defaults to 1.0 (no effect).
 
-    **outlier_score** – read from *outlier_flag_col*; a continuous confidence
+    **outlier_score** – read from *outlier_score_col*; a continuous confidence
     score produced by the outlier-detection pipeline.  Same scale handling as
     quality_score.  Missing column → defaults to 1.0.
 

--- a/src/worldcereal/train/finetuning_utils.py
+++ b/src/worldcereal/train/finetuning_utils.py
@@ -1135,6 +1135,7 @@ def evaluate_finetuned_model(
     seasonal_landcover_classes: Optional[List[str]] = None,
     seasonal_croptype_classes: Optional[List[str]] = None,
     cropland_class_names: Optional[Sequence[str]] = None,
+    weight_threshold: float = 0.0,
 ) -> Union[dict, Tuple[pd.DataFrame, Figure, Figure]]:
     """Evaluate a fine-tuned model on a labelled dataset and report metrics.
 
@@ -1162,6 +1163,12 @@ def evaluate_finetuned_model(
     cropland_class_names : Optional[Sequence[str]]
         Optional list of class names that should trigger cropland gating during
         seasonal evaluation.
+    weight_threshold : float, default 0.0
+        Samples whose task weight is at or below this value are excluded from
+        metrics.  For seasonal heads ``sample_weight_lc`` gates landcover
+        records and ``sample_weight_ct`` gates crop-type records independently.
+        For standard (non-seasonal) heads the minimum of both available weight
+        columns is used; samples at or below the threshold are skipped.
 
     Returns
     -------
@@ -1220,6 +1227,8 @@ def evaluate_finetuned_model(
                     seasonal_landcover_classes,
                     seasonal_croptype_classes,
                     cropland_class_names=cropland_class_names,
+                    lc_weight_threshold=weight_threshold,
+                    ct_weight_threshold=weight_threshold,
                 )
                 seasonal_landcover_records.extend(batch_summary["landcover"])
                 seasonal_croptype_records.extend(batch_summary["croptype"])
@@ -1227,6 +1236,16 @@ def evaluate_finetuned_model(
                 seasonal_mode = True
                 continue
             targets = predictors.label.cpu().numpy().astype(int)
+
+            # Exclude samples whose combined task weight is at or below
+            # weight_threshold before computing any metrics.
+            _wm = _compute_weight_mask(
+                attrs or {}, n_samples=targets.shape[0], threshold=weight_threshold
+            )
+            if not _wm.all():
+                _wm_t = torch.as_tensor(_wm, device=model_output.device)
+                model_output = model_output[_wm_t]
+                targets = targets[_wm]
 
             if test_ds.task_type == "binary":
                 probs = torch.sigmoid(model_output).cpu().numpy()
@@ -1511,6 +1530,33 @@ def _ensure_list(value, expected_len: int, fill=None) -> List:
     return result
 
 
+def _compute_weight_mask(
+    attrs: dict,
+    n_samples: int,
+    threshold: float = 0.0,
+) -> np.ndarray:
+    """Return a boolean array of shape *(n_samples,)* marking valid samples.
+
+    A sample is considered valid when its combined sample weight is *strictly
+    above* ``threshold``.  The combined weight is the element-wise minimum of
+    ``sample_weight_lc`` and ``sample_weight_ct``, whichever keys are present
+    in *attrs*.  When neither key is present all samples are considered valid
+    (mask of all ``True``).
+    """
+    weights = np.ones(n_samples, dtype=float)
+    for key in ("sample_weight_lc", "sample_weight_ct"):
+        val = attrs.get(key)
+        if val is None:
+            continue
+        if torch.is_tensor(val):
+            w = val.detach().cpu().numpy().flatten().astype(float)
+        else:
+            w = np.asarray(val, dtype=float).flatten()
+        if w.shape[0] == n_samples:
+            weights = np.minimum(weights, w)
+    return weights > threshold
+
+
 def _select_representative_season(
     output: SeasonalHeadOutput,
     attrs: dict,
@@ -1595,6 +1641,8 @@ def summarize_seasonal_predictions(
     landcover_task_name: str = "landcover",
     croptype_task_name: str = "croptype",
     enforce_cropland_gate: bool = False,
+    lc_weight_threshold: float = 0.0,
+    ct_weight_threshold: float = 0.0,
 ) -> dict:
     """Convert seasonal logits into per-branch classification records.
 
@@ -1603,12 +1651,18 @@ def summarize_seasonal_predictions(
     they need. When ``enforce_cropland_gate`` is True, crop-type predictions are
     only emitted if either the predicted or labelled landcover class belongs to
     ``cropland_class_names``.
+
+    Samples whose ``sample_weight_lc`` (for landcover) or ``sample_weight_ct``
+    (for crop-type) is at or below the respective threshold are excluded from
+    the returned records.
     """
 
     batch_size = output.global_embedding.shape[0]
     landcover_labels = _ensure_list(attrs.get("landcover_label"), batch_size, fill=None)
     croptype_labels = _ensure_list(attrs.get("croptype_label"), batch_size, fill=None)
     label_tasks = _ensure_list(attrs.get("label_task"), batch_size, fill=None)
+    lc_weights = _ensure_list(attrs.get("sample_weight_lc"), batch_size, fill=1.0)
+    ct_weights = _ensure_list(attrs.get("sample_weight_ct"), batch_size, fill=1.0)
 
     tasks: List[str] = []
     for idx in range(batch_size):
@@ -1650,6 +1704,7 @@ def summarize_seasonal_predictions(
         if landcover_labels[idx] is not None
         and not _is_missing_value(landcover_labels[idx])
         and str(landcover_labels[idx]) in landcover_classes
+        and float(lc_weights[idx]) > lc_weight_threshold
     ]
     if lc_probs is not None:
         for sample_idx in landcover_indices:
@@ -1687,6 +1742,8 @@ def summarize_seasonal_predictions(
             if _is_missing_value(target_name):
                 continue
             if str(target_name) not in croptype_classes:
+                continue
+            if float(ct_weights[sample_idx]) <= ct_weight_threshold:
                 continue
 
             if gating_enabled:

--- a/tests/worldcerealtests/test_finetuning_utils.py
+++ b/tests/worldcerealtests/test_finetuning_utils.py
@@ -112,8 +112,9 @@ class TestAttachSampleWeights(unittest.TestCase):
     def test_zero_quality_gives_zero_weight(self):
         """quality=0 → weight=0 regardless of outlier_score."""
         df = self._make_df(quality=0.0, outlier_score=1.0)
-        result = self._attach(df)
-        np.testing.assert_allclose(result["weight"].to_numpy(), 0.0)
+        with self.assertRaises(ValueError) as cm:
+            self._attach(df)
+        self.assertIn("all sample weights are 0.0", str(cm.exception))
 
     def test_scores_normalized_from_0_100_scale(self):
         """Scores on 0-100 scale are divided by 100 before multiplication."""

--- a/tests/worldcerealtests/test_finetuning_utils.py
+++ b/tests/worldcerealtests/test_finetuning_utils.py
@@ -8,6 +8,7 @@ from prometheo.predictors import NODATAVALUE, Predictors
 from torch import nn
 from torch.utils.data import Dataset
 
+from worldcereal.train import OUTLIER_COLUMNS
 from worldcereal.train.data import get_training_dfs_from_parquet
 from worldcereal.train.datasets import (
     WorldCerealLabelledDataset,  # MaskingMode,; MaskingStrategy,
@@ -15,6 +16,7 @@ from worldcereal.train.datasets import (
 from worldcereal.train.finetuning_utils import (
     SeasonalMultiTaskLoss,
     _select_representative_season,
+    attach_sample_weights,
     evaluate_finetuned_model,
     prepare_training_datasets,
 )
@@ -24,6 +26,190 @@ from worldcereal.utils.refdata import get_class_mappings
 CLASS_MAPPINGS = get_class_mappings()
 LANDCOVER_KEY = "LANDCOVER10"
 CROPTYPE_KEY = "CROPTYPE28"
+
+
+# ---------------------------------------------------------------------------
+# attach_sample_weights
+# ---------------------------------------------------------------------------
+_OUTLIER_FLAG_COL = OUTLIER_COLUMNS["LC_outlier_flag"]  # "LC10_anomaly_flag"
+
+
+class TestAttachSampleWeights(unittest.TestCase):
+    """Unit tests for attach_sample_weights and its helpers.
+
+    Each test builds a minimal DataFrame with the columns that
+    attach_sample_weights / identify_true_outliers rely on, so no
+    real parquet files are required.
+    """
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_df(
+        self,
+        n: int = 4,
+        quality=1.0,
+        outlier_score=1.0,
+        outlier_flag="normal",
+    ) -> pd.DataFrame:
+        """Return a minimal DataFrame for attach_sample_weights."""
+
+        def _to_list(val, length):
+            return val if isinstance(val, list) else [val] * length
+
+        return pd.DataFrame(
+            {
+                "sample_id": [f"s{i}" for i in range(n)],
+                "quality_score": _to_list(quality, n),
+                "outlier_score": _to_list(outlier_score, n),
+                _OUTLIER_FLAG_COL: _to_list(outlier_flag, n),
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    # Convenience wrapper: fixed flag col and drop mode for brevity
+    def _attach(
+        self,
+        df,
+        quality_col="quality_score",
+        outlier_col="outlier_score",
+        flag_col=None,
+        drop_mode="drop_candidate",
+        out_col="weight",
+    ):
+        return attach_sample_weights(
+            df,
+            "train",
+            quality_col,
+            outlier_col,
+            flag_col if flag_col is not None else _OUTLIER_FLAG_COL,
+            drop_mode,
+            out_col,
+        )
+
+    def test_output_column_added(self):
+        """The returned DataFrame must contain the requested output column."""
+        df = self._make_df()
+        result = self._attach(df)
+        self.assertIn("weight", result.columns)
+
+    def test_uniform_perfect_scores_give_weight_one(self):
+        """quality=1.0, outlier_score=1.0, no outlier flag → weight=1.0."""
+        df = self._make_df(quality=1.0, outlier_score=1.0)
+        result = self._attach(df)
+        np.testing.assert_allclose(result["weight"].to_numpy(), 1.0)
+
+    def test_weight_is_product_of_scores(self):
+        """weight == quality × outlier_score for non-outlier samples."""
+        df = self._make_df(quality=0.8, outlier_score=0.7)
+        result = self._attach(df)
+        np.testing.assert_allclose(result["weight"].to_numpy(), 0.8 * 0.7, rtol=1e-6)
+
+    def test_zero_quality_gives_zero_weight(self):
+        """quality=0 → weight=0 regardless of outlier_score."""
+        df = self._make_df(quality=0.0, outlier_score=1.0)
+        result = self._attach(df)
+        np.testing.assert_allclose(result["weight"].to_numpy(), 0.0)
+
+    def test_scores_normalized_from_0_100_scale(self):
+        """Scores on 0-100 scale are divided by 100 before multiplication."""
+        df = self._make_df(quality=80.0, outlier_score=100.0)
+        result = self._attach(df)
+        np.testing.assert_allclose(result["weight"].to_numpy(), 0.8, rtol=1e-6)
+
+    def test_outlier_candidate_gets_zero_weight(self):
+        """A sample flagged 'candidate' must receive weight=0."""
+        df = self._make_df(
+            n=4,
+            quality=[1.0, 1.0, 1.0, 1.0],
+            outlier_score=[1.0, 1.0, 1.0, 1.0],
+            outlier_flag=["normal", "candidate", "normal", "normal"],
+        )
+        result = self._attach(df, drop_mode="drop_candidate")
+        self.assertAlmostEqual(result["weight"].iloc[1], 0.0)
+        # The remaining three non-outlier samples keep weight=1
+        np.testing.assert_allclose(result["weight"].iloc[[0, 2, 3]].to_numpy(), 1.0)
+
+    def test_suspect_not_dropped_at_candidate_level(self):
+        """A sample flagged 'suspect' is kept when drop_mode='drop_candidate'."""
+        df = self._make_df(
+            n=2,
+            quality=[1.0, 1.0],
+            outlier_score=[1.0, 1.0],
+            outlier_flag=["suspect", "normal"],
+        )
+        result = self._attach(df, drop_mode="drop_candidate")
+        np.testing.assert_allclose(result["weight"].to_numpy(), 1.0)
+
+    def test_suspect_dropped_at_suspect_level(self):
+        """A 'suspect' sample is zeroed when drop_mode='drop_suspect'."""
+        df = self._make_df(
+            n=2,
+            quality=[1.0, 1.0],
+            outlier_score=[1.0, 1.0],
+            outlier_flag=["suspect", "normal"],
+        )
+        result = self._attach(df, drop_mode="drop_suspect")
+        self.assertAlmostEqual(result["weight"].iloc[0], 0.0)
+        self.assertAlmostEqual(result["weight"].iloc[1], 1.0)
+
+    def test_missing_quality_column_defaults_to_one(self):
+        """Absent quality column → quality defaults to 1.0 (no effect on weight)."""
+        df = self._make_df(outlier_score=0.6)
+        result = self._attach(df, quality_col="nonexistent_quality")
+        np.testing.assert_allclose(result["weight"].to_numpy(), 0.6, rtol=1e-6)
+
+    def test_missing_outlier_score_column_defaults_to_one(self):
+        """Absent outlier_score column → outlier_score defaults to 1.0."""
+        df = self._make_df(quality=0.7)
+        result = self._attach(df, outlier_col="nonexistent_outlier")
+        np.testing.assert_allclose(result["weight"].to_numpy(), 0.7, rtol=1e-6)
+
+    def test_missing_outlier_flag_column_treated_as_clean(self):
+        """When the outlier flag column is absent all samples are treated as clean."""
+        df = pd.DataFrame(
+            {
+                "sample_id": ["s0", "s1"],
+                "quality_score": [0.9, 0.9],
+                "outlier_score": [1.0, 1.0],
+                # Note: outlier flag column intentionally omitted
+            }
+        )
+        result = self._attach(df, flag_col="missing_flag_col")
+        np.testing.assert_allclose(result["weight"].to_numpy(), 0.9, rtol=1e-6)
+
+    def test_original_dataframe_not_mutated(self):
+        """attach_sample_weights must not modify the input DataFrame in-place."""
+        df = self._make_df()
+        original_cols = set(df.columns)
+        self._attach(df)
+        self.assertEqual(set(df.columns), original_cols)
+        self.assertNotIn("weight", df.columns)
+
+    def test_weights_clipped_to_unit_interval(self):
+        """Scores slightly above 1.0 in a [0,1] range are clipped to 1.0."""
+        df = self._make_df(quality=1.05, outlier_score=1.1)
+        result = self._attach(df)
+        self.assertTrue((result["weight"] >= 0.0).all())
+        self.assertTrue((result["weight"] <= 1.0).all())
+
+    def test_per_sample_variability(self):
+        """Different quality per sample translates to different weights."""
+        df = self._make_df(
+            n=4,
+            quality=[1.0, 0.8, 0.5, 0.2],
+            outlier_score=[1.0, 1.0, 1.0, 1.0],
+        )
+        result = self._attach(df)
+        np.testing.assert_allclose(
+            result["weight"].to_numpy(),
+            [1.0, 0.8, 0.5, 0.2],
+            rtol=1e-6,
+        )
 
 
 class TestPrepareTrainingDatasets(unittest.TestCase):


### PR DESCRIPTION
- Centralize `OUTLIER_COLUMNS` so we no longer have multiple places where column names are hardcoded
- Outliers are no longer dropped from the dataframe, but instead their weights are put to 0; this way we can have diverging outlier handling for landcover vs croptype.
- Evaluation metrics only take into account samples that have a task-specific weight above a certain threshold (default=0)