### PR TITLE
Bugfix: `ewoc_code` needs to be the index

### DIFF
--- a/src/worldcereal/utils/refdata.py
+++ b/src/worldcereal/utils/refdata.py
@@ -135,7 +135,7 @@ def map_classes(
     """
 
     df = df.loc[~df["ewoc_code"].isin(filter_classes)].copy()
-    legend = get_legend()
+    legend = get_legend().set_index("ewoc_code")
 
     # Check if all classes are present in the mapping dictionary
     existing_codes_list = set(df["ewoc_code"].astype(int).astype(str).unique())


### PR DESCRIPTION
Missing codes is class mappings show up as NaN because they cannot be located in the legend. This PR fixes a bug by ensuring `ewoc_code` is the index of the legend dataframe before locating certain codes.