### PR TITLE
S2 masking fix

### DIFF
--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -934,16 +934,14 @@ class WorldCerealDataset(Dataset):
             #     f"Applied S2 cloud block dropout from timestep {start} to {end - 1} (len={block_len})"
             # )
 
-        # 4. Per-timestep S2 cloud dropout (skip already-masked timesteps)
+        # 4. Per-timestep S2 cloud dropout (skip already-masked timesteps).
         if cfg.s2_cloud_timestep_prob > 0:
             s2_mask = np.random.rand(T) < cfg.s2_cloud_timestep_prob
-            # Avoid double logging of block; still mask independent timesteps not in block
-            newly_masked = s2_mask & (s2[0, 0, :, 0] != NODATAVALUE)
+            # Probe B4 to determine which timesteps are newly masked (cloudy) vs already masked
+            b4_idx = S2_BANDS.index("B4")
+            newly_masked = s2_mask & (s2[0, 0, :, b4_idx] != NODATAVALUE)
             if newly_masked.any():
                 s2[..., newly_masked, :] = NODATAVALUE
-                # logger.debug(
-                #     f"Applied S2 per-timestep cloud masking on {newly_masked.sum()} timesteps"
-                # )
 
         # 5. Meteo per-timestep dropout
         if cfg.meteo_timestep_dropout_prob > 0:

--- a/tests/worldcerealtests/test_sensor_masking.py
+++ b/tests/worldcerealtests/test_sensor_masking.py
@@ -102,3 +102,20 @@ def test_dem_dropout():
     ds = WorldCerealDataset(df, num_timesteps=num_timesteps, masking_config=cfg)
     sample = ds[0]
     assert np.all(sample.dem == NODATAVALUE), "DEM dropout failed"
+
+
+def test_s2_cloud_timestep_full_dropout():
+    # Regression: s2_cloud_timestep_prob=1.0 must mask every S2 timestep,
+    # independent of the cloud-block path. A previous bug guarded this path
+    # with a check against the (never-populated) B1 band, making it a no-op.
+    num_timesteps = 8
+    df = _make_dummy_df(num_timesteps, nrows=1)
+    cfg = SensorMaskingConfig(
+        enable=True,
+        s2_cloud_block_prob=0.0,
+        s2_cloud_timestep_prob=1.0,
+        seed=42,
+    )
+    ds = WorldCerealDataset(df, num_timesteps=num_timesteps, masking_config=cfg)
+    sample = ds[0]
+    assert np.all(sample.s2 == NODATAVALUE), "S2 per-timestep full dropout failed"


### PR DESCRIPTION
**BUG:** `disable_s2` and the `s2_cloud_timestep_prob` augmentation were silently no-ops: every "S2-disabled" or "S2-cloudy-timestep" run actually trained on full Sentinel-2.

Per-timestep S2 masking guarded its operation by checking band B1 of S2. but B1 is never populated by the data loader, so its check `band != NODATAVALUE` always returned False.

**Scope:** every `--disable_s2` ablation result is invalid. Default training used weaker S2 cloud augmentation than the config advertised (only the contiguous-block path worked).