### PR TITLE
Use prometheo==v0.0.5 with ndvi mask fix

### DIFF
--- a/src/worldcereal/job.py
+++ b/src/worldcereal/job.py
@@ -39,8 +39,10 @@ from worldcereal.openeo.workflow_config import WorldCerealWorkflowConfig
 from worldcereal.parameters import EmbeddingsParameters, WorldCerealProductType
 from worldcereal.utils.models import load_model_artifact
 
-FEATURE_DEPS_URL = "https://s3.waw3-1.cloudferro.com/project_dependencies/torch_deps_python311.zip"
-PROMETHEO_WHL_URL = "https://s3.waw3-1.cloudferro.com/project_dependencies/prometheo-0.0.3-py3-none-any.whl"
+FEATURE_DEPS_URL = (
+    "https://s3.waw3-1.cloudferro.com/project_dependencies/torch_deps_python311.zip"
+)
+PROMETHEO_WHL_URL = "https://s3.waw3-1.cloudferro.com/project_dependencies/worldcereal/prometheo-0.0.5-py3-none-any.whl"
 WORLDCEREAL_WHL_URL = "https://s3.waw3-1.cloudferro.com/project_dependencies/worldcereal/worldcereal-2.6.1-py3-none-any.whl"
 DEFAULT_INFERENCE_JOB_OPTIONS = {
     "driver-memory": "4g",

--- a/src/worldcereal/openeo/feature_extractor.py
+++ b/src/worldcereal/openeo/feature_extractor.py
@@ -26,7 +26,7 @@ sys.path.append("feature_deps")
 
 import torch  # noqa: E402
 
-PROMETHEO_WHL_URL = "https://s3.waw3-1.cloudferro.com/project_dependencies/prometheo-0.0.3-py3-none-any.whl"
+PROMETHEO_WHL_URL = "https://s3.waw3-1.cloudferro.com/project_dependencies/worldcereal/prometheo-0.0.5-py3-none-any.whl"
 
 GFMAP_BAND_MAPPING = {
     "S2-L2A-B02": "B2",

--- a/src/worldcereal/openeo/inference_catboost.py
+++ b/src/worldcereal/openeo/inference_catboost.py
@@ -42,7 +42,7 @@ except ImportError:
 _MODULE_CACHE_KEY = f"__model_cache_{__name__}"
 
 # Constants
-PROMETHEO_WHL_URL = "https://s3.waw3-1.cloudferro.com/project_dependencies/prometheo-0.0.3-py3-none-any.whl"
+PROMETHEO_WHL_URL = "https://s3.waw3-1.cloudferro.com/project_dependencies/worldcereal/prometheo-0.0.5-py3-none-any.whl"
 
 GFMAP_BAND_MAPPING = {
     "S2-L2A-B02": "B2",


### PR DESCRIPTION
Due to a recently discovered bug in prometheo, NDVI was not properly masked in Presto. This bug has been addressed and is part of release v0.0.5; it's crucial all new workflows use this version of the library instead.

I have updated the reference to the new wheel on s3; **importantly**, UDPs will have to be updated as well! cc @VincentVerelst 