### PR TITLE
Spatially-aware class balancing for DualHeadBatchSampler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,8 @@ train = [
 finetune = [
   "office365-rest-python-client",
   "openpyxl",
-  "tensorboard"
+  "tensorboard",
+  "cartopy", # for nicer diagnostic plots, but not strictly required for finetuning
 ]
 
 notebooks = [

--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -794,6 +794,7 @@ def _get_smoothed_per_bin_class_weights(
             str_labels, lat_bin, lon_bin, method, min_samples_per_bin,
             lat_min, lat_max, lon_min, lon_max,
             min_samples_per_class_per_bin=min_samples_per_class_per_bin,
+            pool_name=pool_name,
         )
     )
     n_lat = grid.shape[1]
@@ -870,6 +871,7 @@ def _build_per_class_weight_grid(
     grid_lat_min: int, grid_lat_max: int,
     grid_lon_min: int, grid_lon_max: int,
     min_samples_per_class_per_bin: Optional[int] = None,
+    pool_name: str = "",
 ) -> Tuple[np.ndarray, Dict[str, int], Dict[str, float], int, int]:
     """Build a (n_classes, n_lat, n_lon) per-class lookup grid.
 

--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -667,6 +667,185 @@ def _get_per_bin_class_weights(
     return weights
 
 
+def _get_smoothed_per_bin_class_weights(
+    labels: np.ndarray,
+    latitudes: np.ndarray,
+    longitudes: np.ndarray,
+    bin_size: float,
+    method: str,
+    clip_range: Optional[Tuple[float, float]],
+    min_samples_per_bin: int = 50,
+    pool_name: str = "",
+) -> np.ndarray:
+    """Per-sample class weights with bilinear interpolation between bin centers.
+
+    Smooths the step changes that ``_get_per_bin_class_weights`` produces at
+    bin boundaries. For each sample, the weight for its class is computed as
+    the bilinear blend of the per-class weight from the four neighbouring
+    bin centers, using the sample's continuous (lat, lon) position.
+
+    Bins below *min_samples_per_bin* are treated as missing in the per-class
+    grid, and the bilinear kernel renormalises over the remaining valid
+    corners only. Samples with all four corners NaN fall back to the global
+    class weight individually.
+
+    A sample exactly at a bin centre yields the same weight as hard
+    binning; a sample at the corner between four bins yields the average
+    of the four corner weights.
+    """
+    if labels.shape != latitudes.shape or labels.shape != longitudes.shape:
+        raise ValueError(
+            "labels, latitudes, longitudes must have the same shape; got "
+            f"{labels.shape}, {latitudes.shape}, {longitudes.shape}"
+        )
+    if min_samples_per_bin < 1:
+        raise ValueError(
+            f"min_samples_per_bin must be >= 1, got {min_samples_per_bin}"
+        )
+    if bin_size <= 0:
+        raise ValueError(f"bin_size must be > 0, got {bin_size}")
+
+    str_labels = labels.astype(str)
+
+    # Hard bin assignment (same as _spatial_bins_from_latlon)
+    lat_bin = np.floor((latitudes + 90.0) / bin_size).astype(np.int64)
+    lon_bin = np.floor((longitudes + 180.0) / bin_size).astype(np.int64)
+
+    # Continuous bin-centre coordinates for bilinear interpolation.
+    u_cont = (latitudes + 90.0) / bin_size - 0.5
+    v_cont = (longitudes + 180.0) / bin_size - 0.5
+    u_floor = np.floor(u_cont).astype(np.int64)
+    v_floor = np.floor(v_cont).astype(np.int64)
+    fu = (u_cont - u_floor).astype(np.float64)
+    fv = (v_cont - v_floor).astype(np.float64)
+
+    # Build the per-class lookup grid (sparse bins → NaN cells, handled by
+    # the valid-only kernel below).
+    all_lat_idx = np.concatenate([u_floor, u_floor + 1])
+    all_lon_idx = np.concatenate([v_floor, v_floor + 1])
+    lat_min, lat_max = int(all_lat_idx.min()), int(all_lat_idx.max())
+    lon_min, lon_max = int(all_lon_idx.min()), int(all_lon_idx.max())
+    grid, class_to_idx, global_w_dict, n_dense_bins, n_total_bins = (
+        _build_per_class_weight_grid(
+            str_labels, lat_bin, lon_bin, method, min_samples_per_bin,
+            lat_min, lat_max, lon_min, lon_max,
+        )
+    )
+    n_lat = grid.shape[1]
+    n_lon = grid.shape[2]
+
+    sample_class_idx = np.array(
+        [class_to_idx[c] for c in str_labels], dtype=np.int64
+    )
+    sample_global_w = np.array(
+        [global_w_dict[c] for c in str_labels], dtype=np.float64
+    )
+
+    def _lookup_corner(
+        li_offset: int, lo_offset: int
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        gi = u_floor + li_offset - lat_min
+        gj = v_floor + lo_offset - lon_min
+        in_bounds = (gi >= 0) & (gi < n_lat) & (gj >= 0) & (gj < n_lon)
+        gi_clip = np.clip(gi, 0, n_lat - 1)
+        gj_clip = np.clip(gj, 0, n_lon - 1)
+        vals = grid[sample_class_idx, gi_clip, gj_clip]
+        valid = in_bounds & ~np.isnan(vals)
+        # Replace NaN with 0 so the masked-out contribution doesn't pollute math.
+        return np.where(valid, vals, 0.0), valid.astype(np.float64)
+
+    v_sw, m_sw = _lookup_corner(0, 0)
+    v_nw, m_nw = _lookup_corner(1, 0)
+    v_se, m_se = _lookup_corner(0, 1)
+    v_ne, m_ne = _lookup_corner(1, 1)
+
+    # Valid-only kernel: weighted sum over real corners; renormalise by the
+    # weight of valid corners only. Samples with no valid corner at all fall
+    # back to the global class weight.
+    b_sw = (1 - fu) * (1 - fv)
+    b_nw = fu * (1 - fv)
+    b_se = (1 - fu) * fv
+    b_ne = fu * fv
+    weighted_sum = b_sw * v_sw + b_nw * v_nw + b_se * v_se + b_ne * v_ne
+    weight_sum = b_sw * m_sw + b_nw * m_nw + b_se * m_se + b_ne * m_ne
+    weights = np.where(
+        weight_sum > 0,
+        weighted_sum / np.maximum(weight_sum, 1e-12),
+        sample_global_w,
+    )
+
+    mean = weights.mean()
+    if mean > 0:
+        weights = weights / mean
+    if clip_range is not None:
+        weights = np.clip(weights, clip_range[0], clip_range[1])
+
+    prefix = (
+        f"_get_smoothed_per_bin_class_weights[{pool_name}]"
+        if pool_name
+        else "_get_smoothed_per_bin_class_weights"
+    )
+    n_sparse_bins = n_total_bins - n_dense_bins
+    logger.info(
+        f"{prefix}: bilinear interpolation across {n_dense_bins}/{n_total_bins} "
+        f"dense bins (min_samples_per_bin={min_samples_per_bin}); "
+        f"{n_sparse_bins} sparse bins and absent (bin, class) corners fall back "
+        "to global class weights."
+    )
+
+    return weights
+
+
+def _build_per_class_weight_grid(
+    str_labels: np.ndarray,
+    lat_bin: np.ndarray,
+    lon_bin: np.ndarray,
+    method: str,
+    min_samples_per_bin: int,
+    grid_lat_min: int, grid_lat_max: int,
+    grid_lon_min: int, grid_lon_max: int,
+) -> Tuple[np.ndarray, Dict[str, int], Dict[str, float], int, int]:
+    """Build a (n_classes, n_lat, n_lon) per-class lookup grid.
+
+    Cells with no data (sparse bin or class absent in a dense bin) are NaN.
+    Returns the grid plus class index map, global weight dict, and
+    (n_dense_bins, n_total_bins) for logging.
+    """
+    df = pd.DataFrame({"lat_bin": lat_bin, "lon_bin": lon_bin, "label": str_labels})
+    bin_groups = df.groupby(["lat_bin", "lon_bin"])
+    bin_weights: Dict[Tuple[int, int], Dict[str, float]] = {}
+    for (li, lo), group in bin_groups:
+        if len(group) < min_samples_per_bin:
+            continue
+        bin_weights[(li, lo)] = _stringify_weight_dict(
+            get_class_weights(
+                group["label"].to_numpy(),
+                method=method, clip_range=None, normalize=True,
+            )
+        )
+    n_total_bins = bin_groups.ngroups
+    n_dense_bins = len(bin_weights)
+
+    global_w_dict = _stringify_weight_dict(
+        get_class_weights(str_labels, method=method, clip_range=None, normalize=True)
+    )
+    unique_classes = sorted(set(str_labels))
+    class_to_idx = {c: i for i, c in enumerate(unique_classes)}
+
+    n_lat = grid_lat_max - grid_lat_min + 1
+    n_lon = grid_lon_max - grid_lon_min + 1
+    grid = np.full((len(unique_classes), n_lat, n_lon), np.nan, dtype=np.float64)
+    for (li, lo), wdict in bin_weights.items():
+        gi = li - grid_lat_min
+        gj = lo - grid_lon_min
+        if not (0 <= gi < n_lat and 0 <= gj < n_lon):
+            continue
+        for cls, w in wdict.items():
+            if cls in class_to_idx:
+                grid[class_to_idx[cls], gi, gj] = w
+    return grid, class_to_idx, global_w_dict, n_dense_bins, n_total_bins
+
+
 @dataclass
 class SensorMaskingConfig:
     """Configuration for simulating real-world missing data scenarios.
@@ -1794,6 +1973,7 @@ class WorldCerealLabelledDataset(WorldCerealDataset):
         spatial_weight_method: str = "log",
         class_balancing_scope: Literal["global", "per_bin"] = "global",
         min_samples_per_bin: int = 50,
+        smoothing: Literal["none", "bilinear"] = "none",
         num_batches: Optional[int] = None,
         generator: Optional[torch.Generator] = None,
     ) -> "DualHeadBatchSampler":
@@ -1814,6 +1994,7 @@ class WorldCerealLabelledDataset(WorldCerealDataset):
             spatial_weight_method=spatial_weight_method,
             class_balancing_scope=class_balancing_scope,
             min_samples_per_bin=min_samples_per_bin,
+            smoothing=smoothing,
             num_batches=num_batches,
             generator=generator,
         )
@@ -1851,6 +2032,10 @@ class DualHeadBatchSampler(Sampler):
         Requires ``spatial_bin_size_degrees`` to be set and lat/lon columns
         to be present.
 
+        With ``smoothing="bilinear"`` (per_bin scope only), each sample's
+        class weight is the bilinear blend of the four neighbouring bin
+        centres' weights (see `_get_smoothed_per_bin_class_weights`).
+
     * **Spatial-density factor** (``spatial_weight_method``):
 
       Applied multiplicatively to whichever class weights are produced above,
@@ -1880,6 +2065,7 @@ class DualHeadBatchSampler(Sampler):
         spatial_weight_method: str = "log",
         class_balancing_scope: Literal["global", "per_bin"] = "global",
         min_samples_per_bin: int = 50,
+        smoothing: Literal["none", "bilinear"] = "none",
         num_batches: Optional[int] = None,
         generator: Optional[torch.Generator] = None,
     ) -> None:
@@ -1890,6 +2076,16 @@ class DualHeadBatchSampler(Sampler):
             raise ValueError(
                 f"class_balancing_scope must be one of {valid_scopes}, got "
                 f"'{class_balancing_scope}'"
+            )
+        valid_smoothing = ("none", "bilinear")
+        if smoothing not in valid_smoothing:
+            raise ValueError(
+                f"smoothing must be one of {valid_smoothing}, got '{smoothing}'"
+            )
+        if smoothing != "none" and class_balancing_scope != "per_bin":
+            raise ValueError(
+                f"smoothing='{smoothing}' only meaningful with "
+                "class_balancing_scope='per_bin'."
             )
 
         N = len(dataframe)
@@ -1933,22 +2129,43 @@ class DualHeadBatchSampler(Sampler):
                     "spatial_bin_size_degrees to be set and lat/lon columns to "
                     "be present in the dataframe."
                 )
-            lc_class_arr = _get_per_bin_class_weights(
-                lc_labels,
-                spatial_bins,
-                method=class_weight_method,
-                clip_range=clip_range,
-                min_samples_per_bin=min_samples_per_bin,
-                pool_name="LC",
-            )
-            ct_class_arr = _get_per_bin_class_weights(
-                ct_labels,
-                spatial_bins[ct_real_indices],
-                method=class_weight_method,
-                clip_range=clip_range,
-                min_samples_per_bin=min_samples_per_bin,
-                pool_name="CT",
-            )
+            if smoothing == "bilinear":
+                lat_arr = dataframe["lat"].to_numpy(dtype=np.float64)
+                lon_arr = dataframe["lon"].to_numpy(dtype=np.float64)
+                lc_class_arr = _get_smoothed_per_bin_class_weights(
+                    lc_labels, lat_arr, lon_arr, spatial_bin_size_degrees,
+                    method=class_weight_method,
+                    clip_range=clip_range,
+                    min_samples_per_bin=min_samples_per_bin,
+                    pool_name="LC",
+                )
+                ct_class_arr = _get_smoothed_per_bin_class_weights(
+                    ct_labels,
+                    lat_arr[ct_real_indices],
+                    lon_arr[ct_real_indices],
+                    spatial_bin_size_degrees,
+                    method=class_weight_method,
+                    clip_range=clip_range,
+                    min_samples_per_bin=min_samples_per_bin,
+                    pool_name="CT",
+                )
+            else:
+                lc_class_arr = _get_per_bin_class_weights(
+                    lc_labels,
+                    spatial_bins,
+                    method=class_weight_method,
+                    clip_range=clip_range,
+                    min_samples_per_bin=min_samples_per_bin,
+                    pool_name="LC",
+                )
+                ct_class_arr = _get_per_bin_class_weights(
+                    ct_labels,
+                    spatial_bins[ct_real_indices],
+                    method=class_weight_method,
+                    clip_range=clip_range,
+                    min_samples_per_bin=min_samples_per_bin,
+                    pool_name="CT",
+                )
         else:
             lc_class_arr = _get_normalized_weights(
                 lc_labels, method=class_weight_method, clip_range=clip_range
@@ -1984,10 +2201,14 @@ class DualHeadBatchSampler(Sampler):
             else "(no spatial-density factor)"
         )
         if class_balancing_scope == "per_bin":
+            if smoothing == "bilinear":
+                smoothing_msg = " smoothing=bilinear"
+            else:
+                smoothing_msg = ""
             logger.info(
                 "DualHeadBatchSampler: per-bin class balancing "
                 f"(method={class_weight_method}, "
-                f"min_samples_per_bin={min_samples_per_bin}) "
+                f"min_samples_per_bin={min_samples_per_bin}{smoothing_msg}) "
                 f"{density_msg}."
             )
         else:

--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -531,7 +531,14 @@ def _get_spatial_density_weights(
     Mirrors the analogous safeguard in `_get_per_bin_class_weights`:
     a bin is considered too sparse to estimate a stable density weight from,
     and is treated as "average density" instead.
+
+    ``min_samples_per_bin=1`` is a no-op for the sparse-bin override (every
+    non-empty bin trivially has >=1 sample); values <1 are rejected.
     """
+    if min_samples_per_bin < 1:
+        raise ValueError(
+            f"min_samples_per_bin must be >= 1, got {min_samples_per_bin}"
+        )
     sp_arr = _get_normalized_weights(spatial_bins, method, clip_range)
 
     if min_samples_per_bin > 1:

--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -476,11 +476,11 @@ def get_class_weights(
         raise ValueError(f"Unknown method: {method}")
 
     if normalize:
-        logger.info("Normalizing weights to mean = 1")
+        logger.debug("Normalizing weights to mean = 1")
         weights = weights / weights.mean()
 
     if clip_range:
-        logger.info(f"Clipping weights to range {clip_range}")
+        logger.debug(f"Clipping weights to range {clip_range}")
         weights = np.clip(weights, clip_range[0], clip_range[1])
 
     rounded = np.round(weights, 3)
@@ -513,6 +513,44 @@ def _get_normalized_weights(
     return np.array([w_dict[str(lbl)] for lbl in labels], dtype=np.float64)
 
 
+def _get_spatial_density_weights(
+    spatial_bins: np.ndarray,
+    method: str,
+    clip_range: Optional[Tuple[float, float]],
+    min_samples_per_bin: int = 50,
+) -> np.ndarray:
+    """Per-sample spatial-density weight, with a sparse-bin override.
+
+    Computes density weights for all bins via `_get_normalized_weights`,
+    then overrides bins below *min_samples_per_bin* to the dataset-mean weight
+    (= 1.0). Without this protection, singleton/sparse bins would be assigned
+    extreme weights from the inverse-density formula (e.g. a 1-sample bin in
+    the Arctic can pin the density factor to its upper clip),
+    blowing up the multiplicative composition with class weights downstream.
+
+    Mirrors the analogous safeguard in `_get_per_bin_class_weights`:
+    a bin is considered too sparse to estimate a stable density weight from,
+    and is treated as "average density" instead.
+    """
+    sp_arr = _get_normalized_weights(spatial_bins, method, clip_range)
+
+    if min_samples_per_bin > 1:
+        bin_counts = pd.Series(spatial_bins).value_counts()
+        sparse_bins = set(bin_counts.index[bin_counts < min_samples_per_bin])
+        if sparse_bins:
+            sparse_mask = pd.Series(spatial_bins).isin(sparse_bins).to_numpy()
+            n_sparse_samples = int(sparse_mask.sum())
+            sp_arr = sp_arr.copy()
+            sp_arr[sparse_mask] = 1.0
+            logger.info(
+                f"_get_spatial_density_weights: {len(sparse_bins)}/"
+                f"{bin_counts.size} bins ({n_sparse_samples}/{len(spatial_bins)} "
+                f"samples) below min_samples_per_bin={min_samples_per_bin}; "
+                "density factor set to 1.0 for those samples."
+            )
+    return sp_arr
+
+
 def _spatial_bins_from_latlon(
     latitudes: pd.Series, longitudes: pd.Series, bin_size: float
 ) -> np.ndarray:
@@ -535,6 +573,98 @@ def _spatial_bins_from_latlon(
     lat_str = lat_bins.astype(str)
     lon_str = lon_bins.astype(str)
     return np.char.add(np.char.add(lat_str, "_"), lon_str)
+
+
+def _get_per_bin_class_weights(
+    labels: np.ndarray,
+    bins: np.ndarray,
+    method: str,
+    clip_range: Optional[Tuple[float, float]],
+    min_samples_per_bin: int = 50,
+    pool_name: str = "",
+) -> np.ndarray:
+    """Per-sample class weights computed *within* each spatial bin.
+
+    For each unique value in *bins*, class weights are derived from the
+    within-bin label distribution via `get_class_weights` (with
+    ``normalize=True`` and no clipping).  Bins containing fewer than
+    *min_samples_per_bin* samples fall back to globally-computed class
+    weights — within-bin counts are too sparse to estimate a stable class
+    distribution otherwise.
+
+    The assembled per-sample array is mean-normalised globally to mean = 1
+    and then clipped to *clip_range*, mirroring the convention used by
+    `_get_normalized_weights` so that downstream multiplicative
+    composition (e.g. with sample-quality weights) behaves predictably.
+
+    With ``method="balanced"`` and dense bins, this gives every (bin, class)
+    pair equal total weight mass, which is the spatial analogue of class
+    balancing: each spatial unit contributes a balanced training signal
+    across classes, regardless of how dominant any single class is in the
+    bin's empirical distribution.
+    """
+    if labels.shape != bins.shape:
+        raise ValueError(
+            f"labels and bins must have the same shape; got "
+            f"labels={labels.shape}, bins={bins.shape}"
+        )
+    if min_samples_per_bin < 1:
+        raise ValueError(
+            f"min_samples_per_bin must be >= 1, got {min_samples_per_bin}"
+        )
+
+    global_w_dict = _stringify_weight_dict(
+        get_class_weights(labels, method=method, clip_range=None, normalize=True)
+    )
+
+    weights = np.empty(len(labels), dtype=np.float64)
+    unique_bins = np.unique(bins)
+    n_fallback_bins = 0
+    n_fallback_samples = 0
+
+    for bin_id in unique_bins:
+        mask = bins == bin_id
+        bin_labels = labels[mask]
+
+        if len(bin_labels) < min_samples_per_bin:
+            n_fallback_bins += 1
+            n_fallback_samples += int(mask.sum())
+            weights[mask] = np.array(
+                [global_w_dict[str(lbl)] for lbl in bin_labels],
+                dtype=np.float64,
+            )
+            continue
+
+        bin_w_dict = _stringify_weight_dict(
+            get_class_weights(
+                bin_labels, method=method, clip_range=None, normalize=True
+            )
+        )
+        weights[mask] = np.array(
+            [bin_w_dict[str(lbl)] for lbl in bin_labels], dtype=np.float64
+        )
+
+    if n_fallback_bins > 0:
+        prefix = (
+            f"_get_per_bin_class_weights[{pool_name}]"
+            if pool_name
+            else "_get_per_bin_class_weights"
+        )
+        logger.info(
+            f"{prefix}: {n_fallback_bins}/{len(unique_bins)} "
+            f"bins ({n_fallback_samples}/{len(labels)} samples) below "
+            f"min_samples_per_bin={min_samples_per_bin}; using global class "
+            "weights for those samples."
+        )
+
+    mean = weights.mean()
+    if mean > 0:
+        weights = weights / mean
+
+    if clip_range is not None:
+        weights = np.clip(weights, clip_range[0], clip_range[1])
+
+    return weights
 
 
 @dataclass
@@ -934,16 +1064,11 @@ class WorldCerealDataset(Dataset):
             #     f"Applied S2 cloud block dropout from timestep {start} to {end - 1} (len={block_len})"
             # )
 
-        # 4. Per-timestep S2 cloud dropout (skip already-masked timesteps)
+        # 4. Per-timestep S2 cloud dropout
         if cfg.s2_cloud_timestep_prob > 0:
             s2_mask = np.random.rand(T) < cfg.s2_cloud_timestep_prob
-            # Avoid double logging of block; still mask independent timesteps not in block
-            newly_masked = s2_mask & (s2[0, 0, :, 0] != NODATAVALUE)
-            if newly_masked.any():
-                s2[..., newly_masked, :] = NODATAVALUE
-                # logger.debug(
-                #     f"Applied S2 per-timestep cloud masking on {newly_masked.sum()} timesteps"
-                # )
+            if s2_mask.any():
+                s2[..., s2_mask, :] = NODATAVALUE
 
         # 5. Meteo per-timestep dropout
         if cfg.meteo_timestep_dropout_prob > 0:
@@ -1664,6 +1789,8 @@ class WorldCerealLabelledDataset(WorldCerealDataset):
         clip_range: Optional[Tuple[float, float]] = (0.1, 10.0),
         spatial_bin_size_degrees: Optional[float] = None,
         spatial_weight_method: str = "log",
+        class_balancing_scope: Literal["global", "per_bin"] = "global",
+        min_samples_per_bin: int = 50,
         num_batches: Optional[int] = None,
         generator: Optional[torch.Generator] = None,
     ) -> "DualHeadBatchSampler":
@@ -1682,6 +1809,8 @@ class WorldCerealLabelledDataset(WorldCerealDataset):
             clip_range=clip_range,
             spatial_bin_size_degrees=spatial_bin_size_degrees,
             spatial_weight_method=spatial_weight_method,
+            class_balancing_scope=class_balancing_scope,
+            min_samples_per_bin=min_samples_per_bin,
             num_batches=num_batches,
             generator=generator,
         )
@@ -1707,11 +1836,29 @@ class DualHeadBatchSampler(Sampler):
     ``croptype_label``, weighted by the ``croptype_label`` class distribution
     over that subset.  The "no-crop" class is included naturally.
 
-    **Spatial weighting** (optional): spatial-density weights are computed and
-    independently clipped to *clip_range* before being multiplied with the class
-    weights.  Both components are normalised to mean = 1 and re-clipped to the
-    same *clip_range* prior to combination, so neither can dominate the other
-    due to differences in absolute range.
+    Sample weighting is composed from two **orthogonal** factors:
+
+    * **Class-weight source** (``class_balancing_scope``):
+
+      - ``"global"`` (default) — class weights computed once over the full
+        training set via `_get_normalized_weights`.
+      - ``"per_bin"`` — class weights computed *within* each lat/lon bin via
+        `_get_per_bin_class_weights`. Bins with fewer than
+        ``min_samples_per_bin`` samples fall back to global class weights.
+        Requires ``spatial_bin_size_degrees`` to be set and lat/lon columns
+        to be present.
+
+    * **Spatial-density factor** (``spatial_weight_method``):
+
+      Applied multiplicatively to whichever class weights are produced above,
+      whenever ``spatial_bin_size_degrees`` is set and
+      ``spatial_weight_method != "none"``.  Normalised to mean = 1 and clipped
+      to *clip_range* independently before multiplication, so the two factors
+      cannot dominate each other due to differences in absolute range.
+      Bins with fewer than ``min_samples_per_bin`` samples are treated as
+      "average density" (weight = 1.0) so that singleton/sparse bins cannot
+      pin the density factor to its upper clip and blow up the composed
+      sampling distribution (see `_get_spatial_density_weights`).
     """
 
     _LC_OFFSET: int = 1  # virtual offset factor for LC pool
@@ -1728,10 +1875,19 @@ class DualHeadBatchSampler(Sampler):
         clip_range: Optional[Tuple[float, float]] = (0.1, 10.0),
         spatial_bin_size_degrees: Optional[float] = None,
         spatial_weight_method: str = "log",
+        class_balancing_scope: Literal["global", "per_bin"] = "global",
+        min_samples_per_bin: int = 50,
         num_batches: Optional[int] = None,
         generator: Optional[torch.Generator] = None,
     ) -> None:
         import math
+
+        valid_scopes = ("global", "per_bin")
+        if class_balancing_scope not in valid_scopes:
+            raise ValueError(
+                f"class_balancing_scope must be one of {valid_scopes}, got "
+                f"'{class_balancing_scope}'"
+            )
 
         N = len(dataframe)
         self._n = N
@@ -1741,11 +1897,7 @@ class DualHeadBatchSampler(Sampler):
             num_batches if num_batches is not None else math.ceil(N / batch_size)
         )
 
-        # ---- LC pool: all N samples weighted by landcover class distribution ----
         lc_labels = dataframe[landcover_column].astype(str).to_numpy()
-        lc_class_arr = _get_normalized_weights(
-            lc_labels, method=class_weight_method, clip_range=clip_range
-        )
 
         # ---- CT pool: samples with a valid (non-null, non-ignore) croptype label ----
         ct_valid = dataframe[croptype_column].notna() & (
@@ -1758,15 +1910,9 @@ class DualHeadBatchSampler(Sampler):
                 "DualHeadBatchSampler requires at least one CT-eligible sample."
             )
         ct_labels = dataframe.loc[ct_valid, croptype_column].astype(str).to_numpy()
-        ct_class_arr = _get_normalized_weights(
-            ct_labels, method=class_weight_method, clip_range=clip_range
-        )
 
-        # ---- Optional spatial weighting ----
-        # Both class and spatial arrays are independently normalised to mean=1 and
-        # re-clipped to clip_range (see _get_normalized_weights) before being
-        # multiplied.  This guarantees that neither component can overrule the
-        # other due to differences in absolute weight range.
+        # ---- Compute spatial bins if degree size is set ----
+        spatial_bins: Optional[np.ndarray] = None
         if (
             spatial_bin_size_degrees is not None
             and "lat" in dataframe.columns
@@ -1775,11 +1921,78 @@ class DualHeadBatchSampler(Sampler):
             spatial_bins = _spatial_bins_from_latlon(
                 dataframe["lat"], dataframe["lon"], spatial_bin_size_degrees
             )
-            sp_arr = _get_normalized_weights(
-                spatial_bins, method=spatial_weight_method, clip_range=clip_range
+
+        # ---- Class weights: source controlled by class_balancing_scope ----
+        if class_balancing_scope == "per_bin":
+            if spatial_bins is None:
+                raise ValueError(
+                    "class_balancing_scope='per_bin' requires "
+                    "spatial_bin_size_degrees to be set and lat/lon columns to "
+                    "be present in the dataframe."
+                )
+            lc_class_arr = _get_per_bin_class_weights(
+                lc_labels,
+                spatial_bins,
+                method=class_weight_method,
+                clip_range=clip_range,
+                min_samples_per_bin=min_samples_per_bin,
+                pool_name="LC",
+            )
+            ct_class_arr = _get_per_bin_class_weights(
+                ct_labels,
+                spatial_bins[ct_real_indices],
+                method=class_weight_method,
+                clip_range=clip_range,
+                min_samples_per_bin=min_samples_per_bin,
+                pool_name="CT",
+            )
+        else:
+            lc_class_arr = _get_normalized_weights(
+                lc_labels, method=class_weight_method, clip_range=clip_range
+            )
+            ct_class_arr = _get_normalized_weights(
+                ct_labels, method=class_weight_method, clip_range=clip_range
+            )
+
+        # ---- Spatial-density factor: independent, applied uniformly ----
+        # Both class and spatial arrays are independently normalised to mean=1
+        # and re-clipped to clip_range (see _get_normalized_weights) before
+        # being multiplied, so neither can dominate due to differences in
+        # absolute weight range. spatial_weight_method='none' or no bins
+        # means the density factor is skipped. Sparse bins (< min_samples_per_bin)
+        # get density weight = 1.0 to prevent singleton bins from blowing up
+        # the multiplicative composition.
+        density_applied = (
+            spatial_bins is not None and spatial_weight_method != "none"
+        )
+        if density_applied:
+            sp_arr = _get_spatial_density_weights(
+                spatial_bins,
+                method=spatial_weight_method,
+                clip_range=clip_range,
+                min_samples_per_bin=min_samples_per_bin,
             )
             lc_class_arr = lc_class_arr * sp_arr  # full N-sample array
-            ct_class_arr = ct_class_arr * sp_arr[ct_real_indices]  # CT subset only
+            ct_class_arr = ct_class_arr * sp_arr[ct_real_indices]  # CT subset
+
+        density_msg = (
+            f"× spatial-density factor (method={spatial_weight_method})"
+            if density_applied
+            else "(no spatial-density factor)"
+        )
+        if class_balancing_scope == "per_bin":
+            logger.info(
+                "DualHeadBatchSampler: per-bin class balancing "
+                f"(method={class_weight_method}, "
+                f"min_samples_per_bin={min_samples_per_bin}) "
+                f"{density_msg}."
+            )
+        else:
+            logger.info(
+                "DualHeadBatchSampler: global class balancing "
+                f"(method={class_weight_method}) "
+                f"{density_msg}."
+            )
 
         # Convert to float64 probability tensors for torch.multinomial
         self._lc_probs = torch.as_tensor(

--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -582,6 +582,7 @@ def _get_per_bin_class_weights(
     clip_range: Optional[Tuple[float, float]],
     min_samples_per_bin: int = 50,
     pool_name: str = "",
+    min_samples_per_class_per_bin: Optional[int] = None,
 ) -> np.ndarray:
     """Per-sample class weights computed *within* each spatial bin.
 
@@ -592,16 +593,13 @@ def _get_per_bin_class_weights(
     weights — within-bin counts are too sparse to estimate a stable class
     distribution otherwise.
 
-    The assembled per-sample array is mean-normalised globally to mean = 1
-    and then clipped to *clip_range*, mirroring the convention used by
-    `_get_normalized_weights` so that downstream multiplicative
-    composition (e.g. with sample-quality weights) behaves predictably.
-
-    With ``method="balanced"`` and dense bins, this gives every (bin, class)
-    pair equal total weight mass, which is the spatial analogue of class
-    balancing: each spatial unit contributes a balanced training signal
-    across classes, regardless of how dominant any single class is in the
-    bin's empirical distribution.
+    Within a bin, classes with fewer than *min_samples_per_class_per_bin*
+    samples are excluded from the within-bin weight computation entirely
+    (they don't count toward ``num_classes`` either, removing the
+    destabilising effect of rare classes on dense ones via the ``k_bin``
+    factor in the ``balanced`` recipe). Samples of those filtered classes
+    inherit the global class weight individually. ``None`` (default)
+    auto-derives as ``max(1, min_samples_per_bin // 10)``.
     """
     if labels.shape != bins.shape:
         raise ValueError(
@@ -612,6 +610,13 @@ def _get_per_bin_class_weights(
         raise ValueError(
             f"min_samples_per_bin must be >= 1, got {min_samples_per_bin}"
         )
+    if min_samples_per_class_per_bin is None:
+        min_samples_per_class_per_bin = max(1, min_samples_per_bin // 10)
+    if min_samples_per_class_per_bin < 1:
+        raise ValueError(
+            f"min_samples_per_class_per_bin must be >= 1, got "
+            f"{min_samples_per_class_per_bin}"
+        )
 
     global_w_dict = _stringify_weight_dict(
         get_class_weights(labels, method=method, clip_range=None, normalize=True)
@@ -621,6 +626,7 @@ def _get_per_bin_class_weights(
     unique_bins = np.unique(bins)
     n_fallback_bins = 0
     n_fallback_samples = 0
+    n_class_filtered_samples = 0
 
     for bin_id in unique_bins:
         mask = bins == bin_id
@@ -635,26 +641,59 @@ def _get_per_bin_class_weights(
             )
             continue
 
+        # Per-class filtering: drop classes with too few samples in this bin.
+        class_counts = pd.Series(bin_labels).value_counts()
+        well_represented = set(
+            class_counts.index[class_counts >= min_samples_per_class_per_bin]
+        )
+        if not well_represented:
+            # No class meets the per-class threshold; fall back wholesale.
+            weights[mask] = np.array(
+                [global_w_dict[str(lbl)] for lbl in bin_labels],
+                dtype=np.float64,
+            )
+            continue
+
+        kept_mask = np.array(
+            [lbl in well_represented for lbl in bin_labels], dtype=bool
+        )
+        filtered_labels = bin_labels[kept_mask]
         bin_w_dict = _stringify_weight_dict(
             get_class_weights(
-                bin_labels, method=method, clip_range=None, normalize=True
+                filtered_labels, method=method,
+                clip_range=None, normalize=True,
             )
         )
-        weights[mask] = np.array(
-            [bin_w_dict[str(lbl)] for lbl in bin_labels], dtype=np.float64
+        per_sample = np.array(
+            [
+                bin_w_dict[str(lbl)] if lbl in well_represented
+                else global_w_dict[str(lbl)]
+                for lbl in bin_labels
+            ],
+            dtype=np.float64,
         )
+        weights[mask] = per_sample
+        n_class_filtered_samples += int((~kept_mask).sum())
 
+    prefix = (
+        f"_get_per_bin_class_weights[{pool_name}]"
+        if pool_name
+        else "_get_per_bin_class_weights"
+    )
     if n_fallback_bins > 0:
-        prefix = (
-            f"_get_per_bin_class_weights[{pool_name}]"
-            if pool_name
-            else "_get_per_bin_class_weights"
-        )
         logger.info(
             f"{prefix}: {n_fallback_bins}/{len(unique_bins)} "
             f"bins ({n_fallback_samples}/{len(labels)} samples) below "
             f"min_samples_per_bin={min_samples_per_bin}; using global class "
             "weights for those samples."
+        )
+    if n_class_filtered_samples > 0:
+        logger.info(
+            f"{prefix}: {n_class_filtered_samples}/{len(labels)} samples "
+            f"belong to a class with < min_samples_per_class_per_bin="
+            f"{min_samples_per_class_per_bin} in their bin; using global "
+            "class weights for those samples (other classes in their bin "
+            "compute as if those samples weren't there)."
         )
 
     mean = weights.mean()
@@ -676,6 +715,7 @@ def _get_smoothed_per_bin_class_weights(
     clip_range: Optional[Tuple[float, float]],
     min_samples_per_bin: int = 50,
     pool_name: str = "",
+    min_samples_per_class_per_bin: Optional[int] = None,
 ) -> np.ndarray:
     """Per-sample class weights with bilinear interpolation between bin centers.
 
@@ -684,10 +724,12 @@ def _get_smoothed_per_bin_class_weights(
     the bilinear blend of the per-class weight from the four neighbouring
     bin centers, using the sample's continuous (lat, lon) position.
 
-    Bins below *min_samples_per_bin* are treated as missing in the per-class
-    grid, and the bilinear kernel renormalises over the remaining valid
-    corners only. Samples with all four corners NaN fall back to the global
-    class weight individually.
+    Bins below *min_samples_per_bin* and (bin, class) pairs below
+    *min_samples_per_class_per_bin* (default ``max(1, min_samples_per_bin //
+    10)``) are treated as missing — both are excluded from the per-bin
+    class-weight computation, and the bilinear kernel renormalises over the
+    remaining valid corners. Samples with all four corners NaN fall back to the
+    global class weight.
 
     A sample exactly at a bin centre yields the same weight as hard
     binning; a sample at the corner between four bins yields the average
@@ -719,8 +761,7 @@ def _get_smoothed_per_bin_class_weights(
     fu = (u_cont - u_floor).astype(np.float64)
     fv = (v_cont - v_floor).astype(np.float64)
 
-    # Build the per-class lookup grid (sparse bins → NaN cells, handled by
-    # the valid-only kernel below).
+    # Build the per-class lookup grid (with sparse-bin and per-class filtering).
     all_lat_idx = np.concatenate([u_floor, u_floor + 1])
     all_lon_idx = np.concatenate([v_floor, v_floor + 1])
     lat_min, lat_max = int(all_lat_idx.min()), int(all_lat_idx.max())
@@ -729,6 +770,7 @@ def _get_smoothed_per_bin_class_weights(
         _build_per_class_weight_grid(
             str_labels, lat_bin, lon_bin, method, min_samples_per_bin,
             lat_min, lat_max, lon_min, lon_max,
+            min_samples_per_class_per_bin=min_samples_per_class_per_bin,
         )
     )
     n_lat = grid.shape[1]
@@ -804,23 +846,41 @@ def _build_per_class_weight_grid(
     min_samples_per_bin: int,
     grid_lat_min: int, grid_lat_max: int,
     grid_lon_min: int, grid_lon_max: int,
+    min_samples_per_class_per_bin: Optional[int] = None,
 ) -> Tuple[np.ndarray, Dict[str, int], Dict[str, float], int, int]:
     """Build a (n_classes, n_lat, n_lon) per-class lookup grid.
 
-    Cells with no data (sparse bin or class absent in a dense bin) are NaN.
+    Cells with no data (sparse bin, class absent in dense bin, or class with
+    fewer than *min_samples_per_class_per_bin* samples in its bin) are NaN.
     Returns the grid plus class index map, global weight dict, and
     (n_dense_bins, n_total_bins) for logging.
+
+    *min_samples_per_class_per_bin* defaults to ``max(1, min_samples_per_bin //
+    10)`` — within each dense bin, classes below this in-bin count are dropped
+    from the per-bin weight computation entirely (no entry in the grid for
+    that class in that bin), so they don't contribute to the ``num_classes``
+    factor for the remaining classes.
     """
+    if min_samples_per_class_per_bin is None:
+        min_samples_per_class_per_bin = max(1, min_samples_per_bin // 10)
+
     df = pd.DataFrame({"lat_bin": lat_bin, "lon_bin": lon_bin, "label": str_labels})
     bin_groups = df.groupby(["lat_bin", "lon_bin"])
     bin_weights: Dict[Tuple[int, int], Dict[str, float]] = {}
     for (li, lo), group in bin_groups:
         if len(group) < min_samples_per_bin:
             continue
+        bin_labels = group["label"].to_numpy()
+        class_counts = pd.Series(bin_labels).value_counts()
+        well_represented = set(
+            class_counts.index[class_counts >= min_samples_per_class_per_bin]
+        )
+        if not well_represented:
+            continue
+        kept = bin_labels[np.isin(bin_labels, list(well_represented))]
         bin_weights[(li, lo)] = _stringify_weight_dict(
             get_class_weights(
-                group["label"].to_numpy(),
-                method=method, clip_range=None, normalize=True,
+                kept, method=method, clip_range=None, normalize=True,
             )
         )
     n_total_bins = bin_groups.ngroups
@@ -1974,6 +2034,7 @@ class WorldCerealLabelledDataset(WorldCerealDataset):
         class_balancing_scope: Literal["global", "per_bin"] = "global",
         min_samples_per_bin: int = 50,
         smoothing: Literal["none", "bilinear"] = "none",
+        min_samples_per_class_per_bin: Optional[int] = None,
         num_batches: Optional[int] = None,
         generator: Optional[torch.Generator] = None,
     ) -> "DualHeadBatchSampler":
@@ -1995,6 +2056,7 @@ class WorldCerealLabelledDataset(WorldCerealDataset):
             class_balancing_scope=class_balancing_scope,
             min_samples_per_bin=min_samples_per_bin,
             smoothing=smoothing,
+            min_samples_per_class_per_bin=min_samples_per_class_per_bin,
             num_batches=num_batches,
             generator=generator,
         )
@@ -2066,6 +2128,7 @@ class DualHeadBatchSampler(Sampler):
         class_balancing_scope: Literal["global", "per_bin"] = "global",
         min_samples_per_bin: int = 50,
         smoothing: Literal["none", "bilinear"] = "none",
+        min_samples_per_class_per_bin: Optional[int] = None,
         num_batches: Optional[int] = None,
         generator: Optional[torch.Generator] = None,
     ) -> None:
@@ -2137,6 +2200,7 @@ class DualHeadBatchSampler(Sampler):
                     method=class_weight_method,
                     clip_range=clip_range,
                     min_samples_per_bin=min_samples_per_bin,
+                    min_samples_per_class_per_bin=min_samples_per_class_per_bin,
                     pool_name="LC",
                 )
                 ct_class_arr = _get_smoothed_per_bin_class_weights(
@@ -2147,6 +2211,7 @@ class DualHeadBatchSampler(Sampler):
                     method=class_weight_method,
                     clip_range=clip_range,
                     min_samples_per_bin=min_samples_per_bin,
+                    min_samples_per_class_per_bin=min_samples_per_class_per_bin,
                     pool_name="CT",
                 )
             else:
@@ -2156,6 +2221,7 @@ class DualHeadBatchSampler(Sampler):
                     method=class_weight_method,
                     clip_range=clip_range,
                     min_samples_per_bin=min_samples_per_bin,
+                    min_samples_per_class_per_bin=min_samples_per_class_per_bin,
                     pool_name="LC",
                 )
                 ct_class_arr = _get_per_bin_class_weights(
@@ -2164,6 +2230,7 @@ class DualHeadBatchSampler(Sampler):
                     method=class_weight_method,
                     clip_range=clip_range,
                     min_samples_per_bin=min_samples_per_bin,
+                    min_samples_per_class_per_bin=min_samples_per_class_per_bin,
                     pool_name="CT",
                 )
         else:

--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -2192,6 +2192,9 @@ class DualHeadBatchSampler(Sampler):
                     "spatial_bin_size_degrees to be set and lat/lon columns to "
                     "be present in the dataframe."
                 )
+            # spatial_bins is not None implies spatial_bin_size_degrees is not None;
+            # the assert is for mypy's type narrowing.
+            assert spatial_bin_size_degrees is not None
             if smoothing == "bilinear":
                 lat_arr = dataframe["lat"].to_numpy(dtype=np.float64)
                 lon_arr = dataframe["lon"].to_numpy(dtype=np.float64)

--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -420,6 +420,8 @@ def get_class_weights(
     clip_range: Optional[tuple] = None,  # e.g. (0.2, 10.0)
     normalize: bool = True,
     counts_override: Optional[Mapping[Any, int]] = None,
+    verbose: bool = True,
+    pool_name: str = "",
 ) -> Dict[Hashable, float]:
     """
     Compute class weights for classification tasks.
@@ -485,7 +487,12 @@ def get_class_weights(
 
     rounded = np.round(weights, 3)
     result = {cls: float(weight) for cls, weight in zip(classes, rounded.tolist())}
-    logger.info(f"Class weights ({method}): {result}")
+    if verbose:
+        display = {
+            str(cls): float(weight) for cls, weight in zip(classes, rounded.tolist())
+        }
+        prefix = f"[{pool_name}] " if pool_name else ""
+        logger.info(f"{prefix}Class weights ({method}): {display}")
     return result
 
 
@@ -499,6 +506,7 @@ def _get_normalized_weights(
     labels: np.ndarray,
     method: str,
     clip_range: Optional[Tuple[float, float]],
+    pool_name: str = "",
 ) -> np.ndarray:
     """Return a per-sample float64 weight array.
 
@@ -508,7 +516,10 @@ def _get_normalized_weights(
     within *clip_range* (when provided).
     """
     w_dict = _stringify_weight_dict(
-        get_class_weights(labels, method=method, clip_range=clip_range, normalize=True)
+        get_class_weights(
+            labels, method=method, clip_range=clip_range, normalize=True,
+            pool_name=pool_name,
+        )
     )
     return np.array([w_dict[str(lbl)] for lbl in labels], dtype=np.float64)
 
@@ -539,7 +550,9 @@ def _get_spatial_density_weights(
         raise ValueError(
             f"min_samples_per_bin must be >= 1, got {min_samples_per_bin}"
         )
-    sp_arr = _get_normalized_weights(spatial_bins, method, clip_range)
+    sp_arr = _get_normalized_weights(
+        spatial_bins, method, clip_range, pool_name="spatial-density"
+    )
 
     if min_samples_per_bin > 1:
         bin_counts = pd.Series(spatial_bins).value_counts()
@@ -626,7 +639,10 @@ def _get_per_bin_class_weights(
         )
 
     global_w_dict = _stringify_weight_dict(
-        get_class_weights(labels, method=method, clip_range=None, normalize=True)
+        get_class_weights(
+            labels, method=method, clip_range=None, normalize=True,
+            pool_name=pool_name,
+        )
     )
 
     weights = np.empty(len(labels), dtype=np.float64)
@@ -668,7 +684,7 @@ def _get_per_bin_class_weights(
         bin_w_dict = _stringify_weight_dict(
             get_class_weights(
                 filtered_labels, method=method,
-                clip_range=None, normalize=True,
+                clip_range=None, normalize=True, verbose=False,
             )
         )
         per_sample = np.array(
@@ -888,13 +904,17 @@ def _build_per_class_weight_grid(
         bin_weights[(li, lo)] = _stringify_weight_dict(
             get_class_weights(
                 kept, method=method, clip_range=None, normalize=True,
+                verbose=False,
             )
         )
     n_total_bins = bin_groups.ngroups
     n_dense_bins = len(bin_weights)
 
     global_w_dict = _stringify_weight_dict(
-        get_class_weights(str_labels, method=method, clip_range=None, normalize=True)
+        get_class_weights(
+            str_labels, method=method, clip_range=None, normalize=True,
+            pool_name=pool_name,
+        )
     )
     unique_classes = sorted(set(str_labels))
     class_to_idx = {c: i for i, c in enumerate(unique_classes)}
@@ -2245,10 +2265,12 @@ class DualHeadBatchSampler(Sampler):
                 )
         else:
             lc_class_arr = _get_normalized_weights(
-                lc_labels, method=class_weight_method, clip_range=clip_range
+                lc_labels, method=class_weight_method, clip_range=clip_range,
+                pool_name="LC",
             )
             ct_class_arr = _get_normalized_weights(
-                ct_labels, method=class_weight_method, clip_range=clip_range
+                ct_labels, method=class_weight_method, clip_range=clip_range,
+                pool_name="CT",
             )
 
         # ---- Spatial-density factor: independent, applied uniformly ----

--- a/src/worldcereal/train/diagnostics.py
+++ b/src/worldcereal/train/diagnostics.py
@@ -1,0 +1,341 @@
+"""Plot per-bin per-class weight grids matching what the sampler uses.
+
+Visualizes the per-sample weights produced by ``DualHeadBatchSampler``
+(its ``_lc_probs`` / ``_ct_probs`` attributes) as a per-(bin, class)
+heatmap on a geographic map. Because those weights already encode every
+dispatch decision the sampler made — class-balancing scope, spatial
+density factor, smoothing, fallbacks, clipping — the plot reflects
+exactly what the model trains on. NaN cells are absent class-bin
+combinations (no samples), highlighted in a distinct color.
+
+`dump_per_bin_class_grids` is the public entry point: given a training
+dataframe and the matching per-sample weights, it writes three
+artifacts per pool to *output_dir*:
+  - per_bin_class_weights_{pool}.png   (one panel per class)
+  - per_bin_sample_counts_{pool}.png   (single map of samples per bin)
+  - per_bin_class_summary_{pool}.csv   (per-class summary stats)
+"""
+
+from pathlib import Path
+from typing import Dict, List, Literal, Tuple
+
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
+import numpy as np
+import pandas as pd
+
+
+try:
+    import cartopy.crs as ccrs
+    import cartopy.feature as cfeature
+    _HAS_CARTOPY = True
+    _MAP_PROJ = ccrs.PlateCarree()
+except ImportError:
+    _HAS_CARTOPY = False
+    _MAP_PROJ = None
+
+
+def _draw_basemap(ax: plt.Axes, extent: Tuple[float, float, float, float]) -> None:
+    if _HAS_CARTOPY:
+        ax.set_extent(extent, crs=_MAP_PROJ)
+        ax.add_feature(cfeature.OCEAN, facecolor="#dfe7ef", zorder=0)
+        ax.add_feature(cfeature.LAND, facecolor="#f7f5ef", zorder=0)
+        ax.add_feature(cfeature.COASTLINE, linewidth=0.5, edgecolor="#555")
+        ax.add_feature(cfeature.BORDERS, linewidth=0.3, edgecolor="#888")
+        gl = ax.gridlines(
+            draw_labels=True, linewidth=0.4, alpha=0.5, linestyle=":",
+            color="#666",
+        )
+        gl.top_labels = False
+        gl.right_labels = False
+        gl.xlabel_style = {"size": 6}
+        gl.ylabel_style = {"size": 6}
+    else:
+        ax.set_xlim(extent[0], extent[1])
+        ax.set_ylim(extent[2], extent[3])
+        ax.set_aspect("equal", adjustable="box")
+        ax.grid(True, alpha=0.3)
+
+
+def _plain_log_formatter() -> mticker.FuncFormatter:
+    return mticker.FuncFormatter(lambda x, _: f"{x:g}")
+
+
+def _make_per_class_grid_plot(
+    grids: Dict[str, np.ndarray],
+    classes: List[str],
+    lat_min: int, lon_min: int, n_lat: int, n_lon: int,
+    bin_size: float,
+    extent: Tuple[float, float, float, float],
+    output_path: Path,
+    title: str,
+) -> None:
+    n_classes = len(classes)
+    n_cols = 3
+    n_rows = (n_classes + n_cols - 1) // n_cols
+
+    subplot_kw = {"projection": _MAP_PROJ} if _HAS_CARTOPY else {}
+    fig, axes = plt.subplots(
+        n_rows, n_cols,
+        figsize=(5 * n_cols, 4.5 * n_rows),
+        subplot_kw=subplot_kw,
+    )
+    axes_flat = np.atleast_2d(axes).flatten()
+
+    # Shared log color norm across panels
+    all_vals = np.concatenate(
+        [g[~np.isnan(g)] for g in grids.values() if not np.all(np.isnan(g))]
+    )
+    vmin = max(float(all_vals.min()), 1e-3)
+    vmax = float(all_vals.max())
+    norm = mcolors.LogNorm(vmin=vmin, vmax=vmax)
+    cmap = plt.colormaps["viridis"].with_extremes(bad="#cccccc")  # NaN -> grey
+
+    # Bin edges in lat/lon
+    lat_edges = (np.arange(n_lat + 1) + lat_min) * bin_size - 90.0
+    lon_edges = (np.arange(n_lon + 1) + lon_min) * bin_size - 180.0
+
+    last_mesh = None
+    for i, cls in enumerate(classes):
+        ax = axes_flat[i]
+        _draw_basemap(ax, extent)
+        grid = grids[cls]
+        masked = np.ma.masked_invalid(grid)
+        kwargs = dict(norm=norm, cmap=cmap, shading="flat")
+        if _HAS_CARTOPY:
+            kwargs["transform"] = _MAP_PROJ
+        last_mesh = ax.pcolormesh(lon_edges, lat_edges, masked, **kwargs)
+        n_present = int(np.sum(~np.isnan(grid)))
+        n_total_pixels = grid.size
+        ax.set_title(
+            f"{cls} ({n_present}/{n_total_pixels} bins with weight)",
+            fontsize=9,
+        )
+
+    # Hide unused subplots
+    for j in range(n_classes, len(axes_flat)):
+        axes_flat[j].set_visible(False)
+
+    fig.suptitle(title, fontsize=14, y=0.995)
+    fig.subplots_adjust(right=0.92)
+    cbar_ax = fig.add_axes([0.94, 0.15, 0.015, 0.7])
+    cbar = fig.colorbar(last_mesh, cax=cbar_ax)
+    cbar.set_label("per-bin balanced class weight", fontsize=9)
+    cbar.ax.yaxis.set_major_locator(
+        mticker.LogLocator(base=10, subs=(1.0, 2.0, 5.0), numticks=20)
+    )
+    cbar.ax.yaxis.set_major_formatter(_plain_log_formatter())
+    cbar.ax.tick_params(labelsize=7)
+    cbar.ax.annotate(
+        f"max = {vmax:.2g}\nmin = {vmin:.2g}\ngrey = NaN (sparse / absent)",
+        xy=(1.05, 1.02), xycoords="axes fraction",
+        ha="left", va="bottom", fontsize=7, color="#444",
+    )
+
+    fig.savefig(output_path, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _make_bin_count_plot(
+    bin_sample_counts: Dict[Tuple[int, int], int],
+    lat_min: int, lon_min: int, n_lat: int, n_lon: int,
+    bin_size: float,
+    extent: Tuple[float, float, float, float],
+    output_path: Path,
+    title: str,
+    min_samples_per_bin: int,
+) -> None:
+    """Single-panel map of total samples per bin (sparsity overview)."""
+    grid = np.full((n_lat, n_lon), np.nan, dtype=np.float64)
+    for (li, lo), n in bin_sample_counts.items():
+        gi = li - lat_min
+        gj = lo - lon_min
+        if 0 <= gi < n_lat and 0 <= gj < n_lon:
+            grid[gi, gj] = n
+
+    subplot_kw = {"projection": _MAP_PROJ} if _HAS_CARTOPY else {}
+    fig, ax = plt.subplots(1, 1, figsize=(8, 6), subplot_kw=subplot_kw)
+    _draw_basemap(ax, extent)
+
+    masked = np.ma.masked_invalid(grid)
+    norm = mcolors.LogNorm(
+        vmin=max(1, np.nanmin(grid)), vmax=float(np.nanmax(grid))
+    )
+    cmap = plt.colormaps["plasma"].with_extremes(bad="#cccccc")
+    lat_edges = (np.arange(n_lat + 1) + lat_min) * bin_size - 90.0
+    lon_edges = (np.arange(n_lon + 1) + lon_min) * bin_size - 180.0
+    kwargs = dict(norm=norm, cmap=cmap, shading="flat")
+    if _HAS_CARTOPY:
+        kwargs["transform"] = _MAP_PROJ
+    mesh = ax.pcolormesh(lon_edges, lat_edges, masked, **kwargs)
+
+    fig.suptitle(title, fontsize=12, y=0.97)
+    fig.subplots_adjust(right=0.88)
+    cbar_ax = fig.add_axes([0.90, 0.15, 0.025, 0.7])
+    cbar = fig.colorbar(mesh, cax=cbar_ax)
+    cbar.set_label("samples per bin", fontsize=9)
+    cbar.ax.yaxis.set_major_locator(
+        mticker.LogLocator(base=10, subs=(1.0, 2.0, 5.0), numticks=20)
+    )
+    cbar.ax.yaxis.set_major_formatter(_plain_log_formatter())
+    cbar.ax.tick_params(labelsize=7)
+    cbar.ax.axhline(min_samples_per_bin, color="red", linestyle="--", linewidth=0.8)
+    cbar.ax.annotate(
+        f"red line = min_samples_per_bin ({min_samples_per_bin})\n"
+        f"grey = empty bins",
+        xy=(1.05, 1.02), xycoords="axes fraction",
+        ha="left", va="bottom", fontsize=7, color="#444",
+    )
+
+    fig.savefig(output_path, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _compute_per_class_grids(
+    df: pd.DataFrame,
+    label_col: str,
+    bin_size: float,
+    per_sample_weights: np.ndarray,
+) -> Tuple[Dict[str, np.ndarray], Dict[Tuple[int, int], int], int, int, int, int]:
+    """Reshape sampler per-sample weights into per-(bin, class) grids.
+
+    Cell value = mean weight of all samples of that class in that bin.
+    For unsmoothed sampler configurations, every sample in a (bin, class)
+    cell has the identical weight, so mean = exact value. Under
+    ``smoothing="bilinear"``, weights vary continuously by lat/lon
+    within a bin and the mean is a representative summary.
+    NaN cell = no samples of that class in that bin.
+    """
+    str_labels = df[label_col].astype(str).to_numpy()
+    lat_bin = np.floor((df["lat"].to_numpy() + 90.0) / bin_size).astype(np.int64)
+    lon_bin = np.floor((df["lon"].to_numpy() + 180.0) / bin_size).astype(np.int64)
+
+    helper_df = pd.DataFrame(
+        {
+            "lat_bin": lat_bin,
+            "lon_bin": lon_bin,
+            "label": str_labels,
+            "weight": per_sample_weights,
+        }
+    )
+    bin_sample_counts: Dict[Tuple[int, int], int] = (
+        helper_df.groupby(["lat_bin", "lon_bin"]).size().to_dict()
+    )
+    cell_weights = (
+        helper_df.groupby(["lat_bin", "lon_bin", "label"])["weight"]
+        .mean()
+        .to_dict()
+    )
+
+    classes = sorted(set(str_labels))
+    lat_min = int(lat_bin.min())
+    lat_max = int(lat_bin.max())
+    lon_min = int(lon_bin.min())
+    lon_max = int(lon_bin.max())
+    n_lat = lat_max - lat_min + 1
+    n_lon = lon_max - lon_min + 1
+
+    grids: Dict[str, np.ndarray] = {
+        cls: np.full((n_lat, n_lon), np.nan, dtype=np.float64) for cls in classes
+    }
+    for (li, lo, cls), w in cell_weights.items():
+        grids[cls][li - lat_min, lo - lon_min] = w
+
+    return grids, bin_sample_counts, lat_min, lon_min, n_lat, n_lon
+
+
+def dump_per_bin_class_grids(
+    df: pd.DataFrame,
+    per_sample_weights: np.ndarray,
+    output_dir: Path,
+    *,
+    bin_size: float,
+    min_samples_per_bin: int,
+    pool: Literal["lc", "ct"],
+) -> None:
+    """Visualize the per-sample sampler weights as a per-(bin, class) grid
+    and write the 3 inspection artifacts (PNG x2 + CSV) for one pool to
+    *output_dir*.
+
+    *per_sample_weights* must come from the constructed sampler — typically
+    ``DualHeadBatchSampler._lc_probs`` for ``pool="lc"`` or
+    ``DualHeadBatchSampler._ct_probs`` for ``pool="ct"``. They already
+    encode every dispatch decision (scope, density, smoothing, fallbacks,
+    clipping), so the plot reflects exactly what the model trains on.
+
+    *min_samples_per_bin* is used only as the threshold annotation on the
+    sample-count map; the weights themselves already incorporate any
+    sparse-bin behavior the sampler chose.
+
+    For ``pool="ct"``, samples without a valid (non-null, non-"ignore")
+    croptype label are dropped before binning, mirroring the CT pool used
+    by `DualHeadBatchSampler`.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if pool == "ct":
+        df = df[
+            df["croptype_label"].notna()
+            & (df["croptype_label"].astype(str) != "ignore")
+        ].reset_index(drop=True)
+        label_col = "croptype_label"
+    else:
+        label_col = "landcover_label"
+
+    if len(per_sample_weights) != len(df):
+        raise ValueError(
+            f"per_sample_weights length {len(per_sample_weights)} does not "
+            f"match {pool.upper()} pool size {len(df)}"
+        )
+
+    # Sampler stores `_lc_probs` / `_ct_probs` sum-normalized to 1
+    # (each value ~ 1/N). Rescale to mean=1 so the plotted weights match
+    # the same units as `get_class_weights`-style logs and the LogNorm
+    # has reasonable dynamic range.
+    per_sample_weights = (
+        np.asarray(per_sample_weights, dtype=np.float64) * len(per_sample_weights)
+    )
+
+    grids, bin_counts, lat_min, lon_min, n_lat, n_lon = _compute_per_class_grids(
+        df, label_col, bin_size, per_sample_weights
+    )
+    classes = sorted(grids.keys())
+
+    pad = 2.0
+    extent = (
+        float(df["lon"].min() - pad), float(df["lon"].max() + pad),
+        float(df["lat"].min() - pad), float(df["lat"].max() + pad),
+    )
+
+    _make_per_class_grid_plot(
+        grids, classes, lat_min, lon_min, n_lat, n_lon, bin_size, extent,
+        output_dir / f"per_bin_class_weights_{pool}.png",
+        f"Sampler weights per (bin, class) — {pool.upper()} pool "
+        f"(bin={bin_size}°)",
+    )
+
+    _make_bin_count_plot(
+        bin_counts, lat_min, lon_min, n_lat, n_lon, bin_size, extent,
+        output_dir / f"per_bin_sample_counts_{pool}.png",
+        f"Samples per bin ({pool.upper()} pool, bin={bin_size}°)",
+        min_samples_per_bin,
+    )
+
+    rows = []
+    for cls in classes:
+        grid = grids[cls]
+        n_bins_with_weight = int(np.sum(~np.isnan(grid)))
+        rows.append({
+            "class": cls,
+            "n_samples_total": int((df[label_col].astype(str) == cls).sum()),
+            "n_bins_with_weight": n_bins_with_weight,
+            "weight_min": float(np.nanmin(grid)) if n_bins_with_weight else np.nan,
+            "weight_max": float(np.nanmax(grid)) if n_bins_with_weight else np.nan,
+            "weight_median": (
+                float(np.nanmedian(grid)) if n_bins_with_weight else np.nan
+            ),
+        })
+    pd.DataFrame(rows).to_csv(
+        output_dir / f"per_bin_class_summary_{pool}.csv", index=False
+    )

--- a/src/worldcereal/train/diagnostics.py
+++ b/src/worldcereal/train/diagnostics.py
@@ -25,7 +25,6 @@ import matplotlib.ticker as mticker
 import numpy as np
 import pandas as pd
 
-
 try:
     import cartopy.crs as ccrs
     import cartopy.feature as cfeature

--- a/tests/worldcerealtests/test_datasets.py
+++ b/tests/worldcerealtests/test_datasets.py
@@ -14,6 +14,7 @@ from worldcereal.train.datasets import (
     WorldCerealLabelledDataset,
     WorldCerealTrainingDataset,
     _get_per_bin_class_weights,
+    _get_smoothed_per_bin_class_weights,
     _get_spatial_density_weights,
     _is_lc_only_dataset,
     align_to_composite_window,
@@ -1886,6 +1887,148 @@ class TestSpatialDensityWeights(unittest.TestCase):
         from worldcereal.train.datasets import _get_normalized_weights
         without_protection = _get_normalized_weights(bins, "log", (0.1, 10.0))
         np.testing.assert_allclose(with_protection, without_protection)
+
+
+class TestSmoothedPerBinClassWeights(unittest.TestCase):
+    """Unit tests for `_get_smoothed_per_bin_class_weights` (bilinear)."""
+
+    def _two_bin_grid(self):
+        """Construct a synthetic dataset with 2 dense bins (5° size).
+
+        Bin (lat∈[0,5°), lon∈[0,5°)): all class 'a' (50 samples)
+        Bin (lat∈[5,10°), lon∈[0,5°)): all class 'b' (50 samples)
+        """
+        n_per_bin = 50
+        # Bin centres are at lat=2.5, 7.5; lon=2.5
+        rng = np.random.default_rng(0)
+        a_lats = rng.uniform(0.0, 5.0, n_per_bin)
+        a_lons = rng.uniform(0.0, 5.0, n_per_bin)
+        b_lats = rng.uniform(5.0, 10.0, n_per_bin)
+        b_lons = rng.uniform(0.0, 5.0, n_per_bin)
+        labels = np.array(["a"] * n_per_bin + ["b"] * n_per_bin)
+        lats = np.concatenate([a_lats, b_lats])
+        lons = np.concatenate([a_lons, b_lons])
+        return labels, lats, lons
+
+    def test_at_bin_center_matches_hard_binning(self):
+        """A sample exactly at the bin centre should get the same weight as the
+        hard-binning helper (since fu=0, fv=0 puts 100% weight on its own bin)."""
+        labels, lats, lons = self._two_bin_grid()
+        # Add a probe sample exactly at bin (0–5°, 0–5°) centre — class 'a'
+        probe_label = "a"
+        probe_lat = 2.5  # bin centre in lat
+        probe_lon = 2.5  # bin centre in lon
+        labels = np.append(labels, probe_label)
+        lats = np.append(lats, probe_lat)
+        lons = np.append(lons, probe_lon)
+        bilinear = _get_smoothed_per_bin_class_weights(
+            labels, lats, lons, bin_size=5.0,
+            method="balanced", clip_range=None, min_samples_per_bin=1,
+        )
+        # Hard binning, same data
+        bins = np.array([
+            f"{int(np.floor((la + 90) / 5))}_{int(np.floor((lo + 180) / 5))}"
+            for la, lo in zip(lats, lons)
+        ])
+        hard = _get_per_bin_class_weights(
+            labels, bins, method="balanced", clip_range=None, min_samples_per_bin=1,
+        )
+        # Bin-centre probe: bilinear and hard should match within renormalisation
+        # tolerance. The two arrays are mean-normalised independently, and
+        # bilinear's other samples pick up small global-fallback contributions
+        # at NW/SE/NE corners (which slightly shifts the global mean), so a
+        # loose rtol covers the inevitable numerical drift.
+        probe_bilinear = bilinear[-1]
+        probe_hard = hard[-1]
+        # In this two-bin balanced setup both should be ≈ 1.0.
+        np.testing.assert_allclose(probe_bilinear, probe_hard, rtol=1e-3)
+
+    def test_at_corner_blends_neighbors(self):
+        """A sample on the edge between two bins gets the average of the two
+        neighbours' class weights."""
+        # Two bins where class 'x' has different per-bin weights.
+        # Bin A: 9 'x' + 1 'y' → class 'x' is locally common, low weight
+        # Bin B: 1 'x' + 9 'y' → class 'x' is locally rare, high weight
+        # Bin C, D: empty (we'll have empty corners → fall back to global)
+        labels = np.array(
+            (["x"] * 9 + ["y"]) +     # bin A around lat=2.5
+            (["x"] + ["y"] * 9)       # bin B around lat=7.5
+        )
+        lats = np.concatenate([
+            np.full(10, 2.5),  # all in bin A (lat 0-5)
+            np.full(10, 7.5),  # all in bin B (lat 5-10)
+        ])
+        lons = np.full(20, 2.5)  # all in lon bin 0-5
+        # Probe sample exactly on the edge between bin A and bin B (lat=5.0)
+        # Class 'x'. Should get average of bin A weight and bin B weight for 'x'.
+        labels = np.append(labels, "x")
+        lats = np.append(lats, 5.0)  # exactly at boundary; fu = 0.5 in u-space
+        lons = np.append(lons, 2.5)
+        bilinear = _get_smoothed_per_bin_class_weights(
+            labels, lats, lons, bin_size=5.0,
+            method="balanced", clip_range=None, min_samples_per_bin=1,
+        )
+        # Hard binning
+        bins = np.array([
+            f"{int(np.floor((la + 90) / 5))}_{int(np.floor((lo + 180) / 5))}"
+            for la, lo in zip(lats, lons)
+        ])
+        hard = _get_per_bin_class_weights(
+            labels, bins, method="balanced", clip_range=None, min_samples_per_bin=1,
+        )
+        # Bin A 'x' weight (hard): from samples 0..8 (labels 'x' in bin A)
+        bin_a_x = hard[0]
+        # Bin B 'x' weight (hard): sample 10 (label 'x' in bin B)
+        bin_b_x = hard[10]
+        # The probe's bilinear value should be ~50/50 of these two.
+        # Hard and bilinear arrays use the same mean normaliser convention but
+        # their distributions differ slightly, so use a reasonable tolerance.
+        probe_bilinear = bilinear[-1]
+        # In hard: bin_a_x < bin_b_x (x is rare in B → high weight there).
+        self.assertGreater(probe_bilinear, bin_a_x * 0.5)  # meaningfully above bin A's weight
+        self.assertLess(probe_bilinear, bin_b_x * 1.0)     # meaningfully below bin B's weight
+
+    def test_global_mean_one(self):
+        """Final per-sample array has mean = 1 by construction."""
+        labels, lats, lons = self._two_bin_grid()
+        weights = _get_smoothed_per_bin_class_weights(
+            labels, lats, lons, bin_size=5.0,
+            method="balanced", clip_range=None, min_samples_per_bin=1,
+        )
+        self.assertAlmostEqual(float(weights.mean()), 1.0, places=6)
+
+    def test_clip_range_applied(self):
+        """Clip range bounds the output."""
+        labels, lats, lons = self._two_bin_grid()
+        weights = _get_smoothed_per_bin_class_weights(
+            labels, lats, lons, bin_size=5.0,
+            method="balanced", clip_range=(0.5, 1.5), min_samples_per_bin=1,
+        )
+        self.assertGreaterEqual(float(weights.min()), 0.5 - 1e-9)
+        self.assertLessEqual(float(weights.max()), 1.5 + 1e-9)
+
+    def test_sparse_bin_falls_back_to_global(self):
+        """A bin below min_samples_per_bin is treated as missing, so its
+        corner contribution falls back to the global class weight."""
+        # 100 'a' in dense bin, 1 'a' in sparse-corner bin
+        labels = np.array(["a"] * 100 + ["a"])
+        lats = np.concatenate([np.full(100, 2.5), [7.5]])  # sparse bin at lat∈[5,10)
+        lons = np.full(101, 2.5)
+        weights = _get_smoothed_per_bin_class_weights(
+            labels, lats, lons, bin_size=5.0,
+            method="balanced", clip_range=None, min_samples_per_bin=10,
+        )
+        # All values should be finite, no errors raised.
+        self.assertTrue(np.all(np.isfinite(weights)))
+
+    def test_shape_mismatch_raises(self):
+        with self.assertRaises(ValueError):
+            _get_smoothed_per_bin_class_weights(
+                np.array(["a", "b"]),
+                np.array([0.0, 0.0, 0.0]),  # wrong length
+                np.array([0.0, 0.0]),
+                bin_size=5.0, method="balanced", clip_range=None,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/worldcerealtests/test_datasets.py
+++ b/tests/worldcerealtests/test_datasets.py
@@ -13,6 +13,8 @@ from worldcereal.train.datasets import (
     WorldCerealDataset,
     WorldCerealLabelledDataset,
     WorldCerealTrainingDataset,
+    _get_per_bin_class_weights,
+    _get_spatial_density_weights,
     _is_lc_only_dataset,
     align_to_composite_window,
     get_dekad_timestamp_components,
@@ -270,6 +272,127 @@ class TestWorldCerealDataset(unittest.TestCase):
             batch_size=4, num_batches=7
         )
         self.assertEqual(len(sampler), 7)
+
+    def test_dual_head_batch_sampler_per_bin_scope(self):
+        """`class_balancing_scope='per_bin'` produces valid batches and
+        different LC sampling probabilities than the default global scope
+        (with the same density factor applied to both)."""
+
+        batch_size = 4
+        spatial_bin_size = 0.2
+
+        global_sampler = self.binary_ds.get_dual_head_batch_sampler(
+            batch_size=batch_size,
+            class_weight_method="balanced",
+            spatial_bin_size_degrees=spatial_bin_size,
+            spatial_weight_method="log",
+            class_balancing_scope="global",
+            min_samples_per_bin=1,
+            num_batches=5,
+        )
+        per_bin_sampler = self.binary_ds.get_dual_head_batch_sampler(
+            batch_size=batch_size,
+            class_weight_method="balanced",
+            spatial_bin_size_degrees=spatial_bin_size,
+            spatial_weight_method="log",
+            class_balancing_scope="per_bin",
+            min_samples_per_bin=1,
+            num_batches=5,
+        )
+
+        # Same density factor in both samplers; only the class-weight source
+        # differs. Probabilities should still differ because per-bin and
+        # global produce different class weights.
+        self.assertFalse(
+            np.allclose(
+                global_sampler._lc_probs.numpy(),
+                per_bin_sampler._lc_probs.numpy(),
+            ),
+            "Per-bin scope unexpectedly produced identical LC probabilities to global scope",
+        )
+
+        # Sampler should still yield well-formed batches.
+        N = len(self.binary_ds)
+        batches = list(per_bin_sampler)
+        self.assertEqual(len(batches), 5)
+        for batch in batches:
+            self.assertEqual(len(batch), batch_size)
+            for idx in batch:
+                self.assertTrue(N <= idx < 3 * N)
+
+    def test_dual_head_batch_sampler_per_bin_requires_spatial(self):
+        """Per-bin scope without spatial_bin_size_degrees should error."""
+        with self.assertRaises(ValueError):
+            self.binary_ds.get_dual_head_batch_sampler(
+                batch_size=4,
+                class_balancing_scope="per_bin",
+                spatial_bin_size_degrees=None,
+                num_batches=1,
+            )
+
+    def test_dual_head_batch_sampler_density_axis_independent(self):
+        """`spatial_weight_method` is orthogonal to `class_balancing_scope`:
+        toggling between 'none' and 'log' (with all else fixed) changes the
+        sampling distribution under both global and per_bin scopes."""
+
+        batch_size = 4
+        spatial_bin_size = 0.2
+
+        common_kwargs = dict(
+            batch_size=batch_size,
+            class_weight_method="balanced",
+            spatial_bin_size_degrees=spatial_bin_size,
+            min_samples_per_bin=1,
+            num_batches=5,
+        )
+
+        # Same scope, different density method → different probs.
+        per_bin_no_density = self.binary_ds.get_dual_head_batch_sampler(
+            **common_kwargs,
+            class_balancing_scope="per_bin",
+            spatial_weight_method="none",
+        )
+        per_bin_log_density = self.binary_ds.get_dual_head_batch_sampler(
+            **common_kwargs,
+            class_balancing_scope="per_bin",
+            spatial_weight_method="log",
+        )
+        self.assertFalse(
+            np.allclose(
+                per_bin_no_density._lc_probs.numpy(),
+                per_bin_log_density._lc_probs.numpy(),
+            ),
+            "spatial_weight_method should change the distribution under per_bin scope",
+        )
+
+        # Same axis under global scope.
+        global_no_density = self.binary_ds.get_dual_head_batch_sampler(
+            **common_kwargs,
+            class_balancing_scope="global",
+            spatial_weight_method="none",
+        )
+        global_log_density = self.binary_ds.get_dual_head_batch_sampler(
+            **common_kwargs,
+            class_balancing_scope="global",
+            spatial_weight_method="log",
+        )
+        self.assertFalse(
+            np.allclose(
+                global_no_density._lc_probs.numpy(),
+                global_log_density._lc_probs.numpy(),
+            ),
+            "spatial_weight_method should change the distribution under global scope",
+        )
+
+    def test_dual_head_batch_sampler_invalid_scope(self):
+        """Unknown class_balancing_scope should error."""
+        with self.assertRaises(ValueError):
+            self.binary_ds.get_dual_head_batch_sampler(
+                batch_size=4,
+                class_balancing_scope="invalid_mode",  # type: ignore[arg-type]
+                spatial_bin_size_degrees=0.2,
+                num_batches=1,
+            )
 
     def test_getitem_lc_virtual_index(self):
         """Feeding an LC virtual index [N, 2N) should override label_task to 'landcover'."""
@@ -1607,6 +1730,162 @@ class TestLcOnlyDatasetHelperAndSeasonMasks(unittest.TestCase):
             )
 
         mocked.assert_called()
+
+
+class TestPerBinClassWeights(unittest.TestCase):
+    """Unit tests for :func:`_get_per_bin_class_weights`."""
+
+    def test_balanced_bin_equal_weights(self):
+        """A bin with a balanced class distribution should yield equal weights."""
+        labels = np.array(["a", "a", "b", "b"])
+        bins = np.array(["B0", "B0", "B0", "B0"])
+        weights = _get_per_bin_class_weights(
+            labels, bins, method="balanced", clip_range=None, min_samples_per_bin=1
+        )
+        np.testing.assert_allclose(weights, np.ones_like(weights))
+
+    def test_within_bin_class_balancing(self):
+        """Rare classes within a bin receive higher weight than dominant classes."""
+        # Bin has 1 'a' and 9 'b' → 'a' weight should be ~9× 'b' weight (balanced).
+        labels = np.array(["a"] + ["b"] * 9)
+        bins = np.array(["B0"] * 10)
+        weights = _get_per_bin_class_weights(
+            labels, bins, method="balanced", clip_range=None, min_samples_per_bin=1
+        )
+        a_weight = weights[labels == "a"][0]
+        b_weight = weights[labels == "b"][0]
+        self.assertGreater(a_weight, b_weight)
+        np.testing.assert_allclose(a_weight / b_weight, 9.0, rtol=1e-6)
+
+    def test_global_mean_is_one(self):
+        """The assembled per-sample array should have mean = 1 after normalisation."""
+        rng = np.random.default_rng(0)
+        labels = rng.choice(["a", "b", "c"], size=200, p=[0.6, 0.3, 0.1])
+        bins = rng.choice(["B0", "B1", "B2", "B3"], size=200)
+        weights = _get_per_bin_class_weights(
+            labels, bins, method="balanced", clip_range=None, min_samples_per_bin=10
+        )
+        self.assertAlmostEqual(float(weights.mean()), 1.0, places=6)
+
+    def test_decouples_class_weight_per_bin(self):
+        """Different bins with different class distributions yield different weights
+        for the same class label."""
+        # Bin 0: 'a' is rare (1/10) → high weight
+        # Bin 1: 'a' is dominant (9/10) → low weight
+        labels = np.array(
+            ["a"] + ["b"] * 9  # bin 0
+            + ["a"] * 9 + ["b"]  # bin 1
+        )
+        bins = np.array(["B0"] * 10 + ["B1"] * 10)
+        weights = _get_per_bin_class_weights(
+            labels, bins, method="balanced", clip_range=None, min_samples_per_bin=1
+        )
+        a_in_b0 = weights[(bins == "B0") & (labels == "a")][0]
+        a_in_b1 = weights[(bins == "B1") & (labels == "a")][0]
+        self.assertGreater(a_in_b0, a_in_b1)
+
+    def test_sparse_bin_falls_back_to_global(self):
+        """Bins below min_samples_per_bin use global class weights, not within-bin.
+
+        Setup designed to make fallback observable:
+          * Dense bin B0: 100 'b' samples (single class) → within-bin gives 1.0.
+          * Sparse bin B1: 1 'a' + 1 'b' (size 2, below the threshold).
+
+        If B1 *incorrectly* used within-bin weights, both samples there would
+        receive the same weight (single 'a' + single 'b' → balanced 1:1).
+        With the correct fallback to global, 'a' is globally rare (1 of 102)
+        so its weight should be far higher than 'b'.
+        """
+        labels = np.array(["b"] * 100 + ["a", "b"])
+        bins = np.array(["B0"] * 100 + ["B1", "B1"])
+        weights = _get_per_bin_class_weights(
+            labels, bins, method="balanced", clip_range=None, min_samples_per_bin=10
+        )
+        sparse_a = float(weights[(bins == "B1") & (labels == "a")][0])
+        sparse_b = float(weights[(bins == "B1") & (labels == "b")][0])
+        # Fallback applied → 'a' weight ≫ 'b' weight (no fallback would give equal).
+        self.assertGreater(sparse_a, 10 * sparse_b)
+
+    def test_clip_range_applied(self):
+        """Clipping should bound the final per-sample weights."""
+        # Extreme imbalance within bin → uncapped weights would exceed 5.0
+        labels = np.array(["a"] + ["b"] * 99)
+        bins = np.array(["B0"] * 100)
+        clipped = _get_per_bin_class_weights(
+            labels,
+            bins,
+            method="balanced",
+            clip_range=(0.5, 5.0),
+            min_samples_per_bin=1,
+        )
+        self.assertLessEqual(float(clipped.max()), 5.0 + 1e-9)
+        self.assertGreaterEqual(float(clipped.min()), 0.5 - 1e-9)
+
+    def test_shape_mismatch_raises(self):
+        labels = np.array(["a", "b"])
+        bins = np.array(["B0", "B0", "B0"])
+        with self.assertRaises(ValueError):
+            _get_per_bin_class_weights(
+                labels,
+                bins,
+                method="balanced",
+                clip_range=None,
+                min_samples_per_bin=1,
+            )
+
+    def test_invalid_min_samples_raises(self):
+        labels = np.array(["a", "b"])
+        bins = np.array(["B0", "B0"])
+        with self.assertRaises(ValueError):
+            _get_per_bin_class_weights(
+                labels,
+                bins,
+                method="balanced",
+                clip_range=None,
+                min_samples_per_bin=0,
+            )
+
+
+class TestSpatialDensityWeights(unittest.TestCase):
+    """Unit tests for :func:`_get_spatial_density_weights`."""
+
+    def test_sparse_bin_overridden_to_one(self):
+        """Singleton bins should be set to 1.0 instead of the inverse-density value."""
+        # 100 samples in bin "dense", 1 sample in bin "sparse".
+        bins = np.array(["dense"] * 100 + ["sparse"])
+        weights = _get_spatial_density_weights(
+            bins, method="log", clip_range=(0.1, 10.0), min_samples_per_bin=10
+        )
+        # The sparse-bin sample should be exactly 1.0 (overridden).
+        self.assertAlmostEqual(float(weights[-1]), 1.0)
+        # Without override, the singleton sparse bin would have a high
+        # log-inverse-density weight; with override it's 1.0, well below
+        # the clip ceiling.
+        self.assertLess(float(weights[-1]), 10.0)
+
+    def test_no_sparse_bins_keeps_normalized_weights(self):
+        """When all bins exceed min_samples_per_bin, output matches the
+        un-protected normalized weights."""
+        # Two bins, both above threshold.
+        bins = np.array(["a"] * 50 + ["b"] * 50)
+        with_protection = _get_spatial_density_weights(
+            bins, method="log", clip_range=(0.1, 10.0), min_samples_per_bin=10
+        )
+        # Re-import to compute the un-protected baseline directly.
+        from worldcereal.train.datasets import _get_normalized_weights
+        without_protection = _get_normalized_weights(bins, "log", (0.1, 10.0))
+        np.testing.assert_allclose(with_protection, without_protection)
+
+    def test_min_samples_one_disables_protection(self):
+        """min_samples_per_bin=1 means no override; behaviour matches the un-
+        protected helper exactly."""
+        bins = np.array(["a"] * 100 + ["b"])  # one singleton bin
+        with_protection = _get_spatial_density_weights(
+            bins, method="log", clip_range=(0.1, 10.0), min_samples_per_bin=1
+        )
+        from worldcereal.train.datasets import _get_normalized_weights
+        without_protection = _get_normalized_weights(bins, "log", (0.1, 10.0))
+        np.testing.assert_allclose(with_protection, without_protection)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds an optional per-bin class-weighting mode to the dual-head batch sampler so class weights can be derived locally per lat/lon bin instead of once globally. Default behaviour is unchanged.

**What's new**
* `_get_per_bin_class_weights`: computes class weights within each lat/lon bin via the existing `get_class_weights` machinery. Bins below a configurable `min_samples_per_bin` (default 50) fall back to the globally-computed weights. 
* `_get_spatial_density_weights`: wraps the existing density-factor computation with a sparse-bin override: bins below `min_samples_per_bin` get weight = 1.0 instead of an extreme inverse-density value. Without this, singleton bins (e.g. one sample in a remote ocean cell) pin the density factor to its upper clip and blow up the multiplicative composition with class weights.
* `DualHeadBatchSampler` refactor: exposes two new orthogonal axes:
    * `class_balancing_scope: Literal["global", "per_bin"]` - source of class weights.
    * `spatial_weight_method` (existing) controls the density factor independently and can be set to "none" to skip it.
    * Both axes compose multiplicatively. Useful combinations include per_bin × none (within-bin class balance only) and per_bin × balanced (within-bin balance + cross-bin density equalisation).

**Backward compatibility**
Default `class_balancing_scope="global"` reproduces the previous behaviour exactly.

**UPD:**
* Added  inspectable artifacts so we can sanity-check what the sampler actually draws with - useful for debugging sparsity, fallbacks, and density effects when using spatial bin based balancing.
* New module: `worldcereal/train/diagnostics.py`. Standalone home for training-time inspection helpers; first occupant is `dump_per_bin_class_grids`. Keeps `datasets.py` focused on data/sampler logic and gives future diagnostics an obvious place to land.