### PR TITLE
Adding finetune utilities

### DIFF
--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -2089,6 +2089,7 @@ class WorldCerealLabelledDataset(WorldCerealDataset):
         min_samples_per_class_per_bin: Optional[int] = None,
         num_batches: Optional[int] = None,
         generator: Optional[torch.Generator] = None,
+        class_weight_multipliers: Optional[Mapping[str, float]] = None,
     ) -> "DualHeadBatchSampler":
         """Build a :class:`DualHeadBatchSampler` for dual-head training.
 
@@ -2111,6 +2112,7 @@ class WorldCerealLabelledDataset(WorldCerealDataset):
             min_samples_per_class_per_bin=min_samples_per_class_per_bin,
             num_batches=num_batches,
             generator=generator,
+            class_weight_multipliers=class_weight_multipliers,
         )
 
 
@@ -2183,6 +2185,7 @@ class DualHeadBatchSampler(Sampler):
         min_samples_per_class_per_bin: Optional[int] = None,
         num_batches: Optional[int] = None,
         generator: Optional[torch.Generator] = None,
+        class_weight_multipliers: Optional[Mapping[str, float]] = None,
     ) -> None:
         import math
 
@@ -2304,6 +2307,37 @@ class DualHeadBatchSampler(Sampler):
                 clip_range=clip_range,
                 pool_name="CT",
             )
+
+        # ---- Optional per-class weight multipliers (routed to LC or CT by label membership) ----
+        if class_weight_multipliers:
+            lc_label_set = set(lc_labels.tolist())
+            ct_label_set = set(ct_labels.tolist())
+            lc_multipliers: Dict[str, float] = {}
+            ct_multipliers: Dict[str, float] = {}
+            for key, val in class_weight_multipliers.items():
+                if key in lc_label_set:
+                    lc_multipliers[key] = val
+                elif key in ct_label_set:
+                    ct_multipliers[key] = val
+                else:
+                    logger.warning(
+                        f"class_weight_multipliers key '{key}' not found in LC or CT "
+                        "labels; ignoring."
+                    )
+            if lc_multipliers:
+                lc_multiplier_arr = np.array(
+                    [lc_multipliers.get(str(lbl), 1.0) for lbl in lc_labels],
+                    dtype=np.float64,
+                )
+                lc_class_arr = lc_class_arr * lc_multiplier_arr
+                logger.info(f"Applied LC class weight multipliers: {lc_multipliers}")
+            if ct_multipliers:
+                ct_multiplier_arr = np.array(
+                    [ct_multipliers.get(str(lbl), 1.0) for lbl in ct_labels],
+                    dtype=np.float64,
+                )
+                ct_class_arr = ct_class_arr * ct_multiplier_arr
+                logger.info(f"Applied CT class weight multipliers: {ct_multipliers}")
 
         # ---- Spatial-density factor: independent, applied uniformly ----
         # Both class and spatial arrays are independently normalised to mean=1

--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -2251,7 +2251,10 @@ class DualHeadBatchSampler(Sampler):
                 lat_arr = dataframe["lat"].to_numpy(dtype=np.float64)
                 lon_arr = dataframe["lon"].to_numpy(dtype=np.float64)
                 lc_class_arr = _get_smoothed_per_bin_class_weights(
-                    lc_labels, lat_arr, lon_arr, spatial_bin_size_degrees,
+                    lc_labels,
+                    lat_arr,
+                    lon_arr,
+                    spatial_bin_size_degrees,
                     method=class_weight_method,
                     clip_range=clip_range,
                     min_samples_per_bin=min_samples_per_bin,
@@ -2290,11 +2293,15 @@ class DualHeadBatchSampler(Sampler):
                 )
         else:
             lc_class_arr = _get_normalized_weights(
-                lc_labels, method=class_weight_method, clip_range=clip_range,
+                lc_labels,
+                method=class_weight_method,
+                clip_range=clip_range,
                 pool_name="LC",
             )
             ct_class_arr = _get_normalized_weights(
-                ct_labels, method=class_weight_method, clip_range=clip_range,
+                ct_labels,
+                method=class_weight_method,
+                clip_range=clip_range,
                 pool_name="CT",
             )
 
@@ -2306,9 +2313,7 @@ class DualHeadBatchSampler(Sampler):
         # means the density factor is skipped. Sparse bins (< min_samples_per_bin)
         # get density weight = 1.0 to prevent singleton bins from blowing up
         # the multiplicative composition.
-        density_applied = (
-            spatial_bins is not None and spatial_weight_method != "none"
-        )
+        density_applied = spatial_bins is not None and spatial_weight_method != "none"
         if density_applied:
             sp_arr = _get_spatial_density_weights(
                 spatial_bins,

--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -2315,11 +2315,14 @@ class DualHeadBatchSampler(Sampler):
             lc_multipliers: Dict[str, float] = {}
             ct_multipliers: Dict[str, float] = {}
             for key, val in class_weight_multipliers.items():
+                found = False
                 if key in lc_label_set:
                     lc_multipliers[key] = val
-                elif key in ct_label_set:
+                    found = True
+                if key in ct_label_set:
                     ct_multipliers[key] = val
-                else:
+                    found = True
+                if not found:
                     logger.warning(
                         f"class_weight_multipliers key '{key}' not found in LC or CT "
                         "labels; ignoring."

--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -518,7 +518,10 @@ def _get_normalized_weights(
     """
     w_dict = _stringify_weight_dict(
         get_class_weights(
-            labels, method=method, clip_range=clip_range, normalize=True,
+            labels,
+            method=method,
+            clip_range=clip_range,
+            normalize=True,
             pool_name=pool_name,
         )
     )
@@ -548,9 +551,7 @@ def _get_spatial_density_weights(
     non-empty bin trivially has >=1 sample); values <1 are rejected.
     """
     if min_samples_per_bin < 1:
-        raise ValueError(
-            f"min_samples_per_bin must be >= 1, got {min_samples_per_bin}"
-        )
+        raise ValueError(f"min_samples_per_bin must be >= 1, got {min_samples_per_bin}")
     sp_arr = _get_normalized_weights(
         spatial_bins, method, clip_range, pool_name="spatial-density"
     )
@@ -628,9 +629,7 @@ def _get_per_bin_class_weights(
             f"labels={labels.shape}, bins={bins.shape}"
         )
     if min_samples_per_bin < 1:
-        raise ValueError(
-            f"min_samples_per_bin must be >= 1, got {min_samples_per_bin}"
-        )
+        raise ValueError(f"min_samples_per_bin must be >= 1, got {min_samples_per_bin}")
     if min_samples_per_class_per_bin is None:
         min_samples_per_class_per_bin = max(1, min_samples_per_bin // 10)
     if min_samples_per_class_per_bin < 1:
@@ -641,7 +640,10 @@ def _get_per_bin_class_weights(
 
     global_w_dict = _stringify_weight_dict(
         get_class_weights(
-            labels, method=method, clip_range=None, normalize=True,
+            labels,
+            method=method,
+            clip_range=None,
+            normalize=True,
             pool_name=pool_name,
         )
     )
@@ -684,13 +686,17 @@ def _get_per_bin_class_weights(
         filtered_labels = bin_labels[kept_mask]
         bin_w_dict = _stringify_weight_dict(
             get_class_weights(
-                filtered_labels, method=method,
-                clip_range=None, normalize=True, verbose=False,
+                filtered_labels,
+                method=method,
+                clip_range=None,
+                normalize=True,
+                verbose=False,
             )
         )
         per_sample = np.array(
             [
-                bin_w_dict[str(lbl)] if lbl in well_represented
+                bin_w_dict[str(lbl)]
+                if lbl in well_represented
                 else global_w_dict[str(lbl)]
                 for lbl in bin_labels
             ],
@@ -765,9 +771,7 @@ def _get_smoothed_per_bin_class_weights(
             f"{labels.shape}, {latitudes.shape}, {longitudes.shape}"
         )
     if min_samples_per_bin < 1:
-        raise ValueError(
-            f"min_samples_per_bin must be >= 1, got {min_samples_per_bin}"
-        )
+        raise ValueError(f"min_samples_per_bin must be >= 1, got {min_samples_per_bin}")
     if bin_size <= 0:
         raise ValueError(f"bin_size must be > 0, got {bin_size}")
 
@@ -792,8 +796,15 @@ def _get_smoothed_per_bin_class_weights(
     lon_min, lon_max = int(all_lon_idx.min()), int(all_lon_idx.max())
     grid, class_to_idx, global_w_dict, n_dense_bins, n_total_bins = (
         _build_per_class_weight_grid(
-            str_labels, lat_bin, lon_bin, method, min_samples_per_bin,
-            lat_min, lat_max, lon_min, lon_max,
+            str_labels,
+            lat_bin,
+            lon_bin,
+            method,
+            min_samples_per_bin,
+            lat_min,
+            lat_max,
+            lon_min,
+            lon_max,
             min_samples_per_class_per_bin=min_samples_per_class_per_bin,
             pool_name=pool_name,
         )
@@ -801,16 +812,10 @@ def _get_smoothed_per_bin_class_weights(
     n_lat = grid.shape[1]
     n_lon = grid.shape[2]
 
-    sample_class_idx = np.array(
-        [class_to_idx[c] for c in str_labels], dtype=np.int64
-    )
-    sample_global_w = np.array(
-        [global_w_dict[c] for c in str_labels], dtype=np.float64
-    )
+    sample_class_idx = np.array([class_to_idx[c] for c in str_labels], dtype=np.int64)
+    sample_global_w = np.array([global_w_dict[c] for c in str_labels], dtype=np.float64)
 
-    def _lookup_corner(
-        li_offset: int, lo_offset: int
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    def _lookup_corner(li_offset: int, lo_offset: int) -> Tuple[np.ndarray, np.ndarray]:
         gi = u_floor + li_offset - lat_min
         gj = v_floor + lo_offset - lon_min
         in_bounds = (gi >= 0) & (gi < n_lat) & (gj >= 0) & (gj < n_lon)
@@ -869,8 +874,10 @@ def _build_per_class_weight_grid(
     lon_bin: np.ndarray,
     method: str,
     min_samples_per_bin: int,
-    grid_lat_min: int, grid_lat_max: int,
-    grid_lon_min: int, grid_lon_max: int,
+    grid_lat_min: int,
+    grid_lat_max: int,
+    grid_lon_min: int,
+    grid_lon_max: int,
     min_samples_per_class_per_bin: Optional[int] = None,
     pool_name: str = "",
 ) -> Tuple[np.ndarray, Dict[str, int], Dict[str, float], int, int]:
@@ -906,7 +913,10 @@ def _build_per_class_weight_grid(
         kept = bin_labels[np.isin(bin_labels, list(well_represented))]
         bin_weights[(li, lo)] = _stringify_weight_dict(
             get_class_weights(
-                kept, method=method, clip_range=None, normalize=True,
+                kept,
+                method=method,
+                clip_range=None,
+                normalize=True,
                 verbose=False,
             )
         )
@@ -915,7 +925,10 @@ def _build_per_class_weight_grid(
 
     global_w_dict = _stringify_weight_dict(
         get_class_weights(
-            str_labels, method=method, clip_range=None, normalize=True,
+            str_labels,
+            method=method,
+            clip_range=None,
+            normalize=True,
             pool_name=pool_name,
         )
     )

--- a/src/worldcereal/train/finetuning_utils.py
+++ b/src/worldcereal/train/finetuning_utils.py
@@ -2575,11 +2575,19 @@ def run_finetuning(
         cur_ct_f1 = seasonal_metrics_flat.get("croptype/f1_macro", -1.0)
         cur_mean_f1 = (cur_lc_f1 + cur_ct_f1) / 2.0
 
-        if checkpoint_metric == "lc_f1":
+        # F1-based metrics require seasonal outputs; fall back to val_loss for
+        # non-seasonal models where seasonal_metrics_flat is always empty.
+        _effective_metric = (
+            checkpoint_metric
+            if checkpoint_metric == "val_loss" or seasonal_metrics_supported
+            else "val_loss"
+        )
+
+        if _effective_metric == "lc_f1":
             loss_improved = best_lc_f1 is None or cur_lc_f1 > best_lc_f1
-        elif checkpoint_metric == "ct_f1":
+        elif _effective_metric == "ct_f1":
             loss_improved = best_ct_f1 is None or cur_ct_f1 > best_ct_f1
-        elif checkpoint_metric == "mean_f1":
+        elif _effective_metric == "mean_f1":
             loss_improved = best_mean_f1 is None or cur_mean_f1 > best_mean_f1
         else:
             loss_improved = best_loss is None or current_val_loss < best_loss
@@ -2590,17 +2598,17 @@ def run_finetuning(
             best_ct_f1 = cur_ct_f1
             best_mean_f1 = cur_mean_f1
             epochs_since_improvement = 0
-            if checkpoint_metric == "lc_f1":
+            if _effective_metric == "lc_f1":
                 logger.info(
                     f"Epoch {epoch + 1}: val LC F1 improved to {cur_lc_f1:.4f} "
                     f"(val_loss={current_val_loss:.4f})"
                 )
-            elif checkpoint_metric == "ct_f1":
+            elif _effective_metric == "ct_f1":
                 logger.info(
                     f"Epoch {epoch + 1}: val CT F1 improved to {cur_ct_f1:.4f} "
                     f"(val_loss={current_val_loss:.4f})"
                 )
-            elif checkpoint_metric == "mean_f1":
+            elif _effective_metric == "mean_f1":
                 logger.info(
                     f"Epoch {epoch + 1}: val mean F1 improved to {cur_mean_f1:.4f} "
                     f"(lc={cur_lc_f1:.4f}, ct={cur_ct_f1:.4f}, val_loss={current_val_loss:.4f})"
@@ -2665,11 +2673,11 @@ def run_finetuning(
         _f1_str = ""
         if cur_lc_f1 > 0 or cur_ct_f1 > 0:
             _f1_str = f" | F1 lc={cur_lc_f1:.3f} ct={cur_ct_f1:.3f}"
-        if checkpoint_metric == "lc_f1":
+        if _effective_metric == "lc_f1":
             _best_str = f"{best_lc_f1:.3f} (lc_f1)" if best_lc_f1 is not None else "n/a"
-        elif checkpoint_metric == "ct_f1":
+        elif _effective_metric == "ct_f1":
             _best_str = f"{best_ct_f1:.3f} (ct_f1)" if best_ct_f1 is not None else "n/a"
-        elif checkpoint_metric == "mean_f1":
+        elif _effective_metric == "mean_f1":
             _best_str = (
                 f"{best_mean_f1:.3f} (mean_f1)" if best_mean_f1 is not None else "n/a"
             )

--- a/src/worldcereal/train/finetuning_utils.py
+++ b/src/worldcereal/train/finetuning_utils.py
@@ -581,7 +581,9 @@ def plot_spatial_predictions(
     df = pd.DataFrame(records)
     df = df.dropna(subset=["lat", "lon"])
     if df.empty:
-        logger.debug(f"{task_name}: no lat/lon coordinates in records; skipping spatial plot.")
+        logger.debug(
+            f"{task_name}: no lat/lon coordinates in records; skipping spatial plot."
+        )
         return
 
     n_total = len(df)
@@ -625,6 +627,7 @@ def plot_spatial_predictions(
     # World background (geopandas naturalearth, optional)
     try:
         import geopandas as gpd  # noqa: PLC0415
+
         world = gpd.read_file(gpd.datasets.get_path("naturalearth_lowres"))
         world.plot(ax=ax, color="#e8e8e8", edgecolor="white", linewidth=0.3, zorder=1)
     except Exception:  # noqa: BLE001

--- a/src/worldcereal/train/finetuning_utils.py
+++ b/src/worldcereal/train/finetuning_utils.py
@@ -2196,6 +2196,21 @@ def run_finetuning(
     originally_frozen_layers = set()
 
     track_croptype_supervision = isinstance(loss_fn, SeasonalMultiTaskLoss)
+    # Hoisted here: loss_fn is constant for the entire run so these never change.
+    seasonal_loss = loss_fn if isinstance(loss_fn, SeasonalMultiTaskLoss) else None
+    seasonal_metrics_supported = seasonal_loss is not None
+    # _effective_metric similarly depends only on checkpoint_metric and
+    # seasonal_metrics_supported, both constant → compute once.
+    _effective_metric = (
+        checkpoint_metric
+        if checkpoint_metric == "val_loss" or seasonal_metrics_supported
+        else "val_loss"
+    )
+    if _effective_metric != checkpoint_metric:
+        logger.warning(
+            f"checkpoint_metric='{checkpoint_metric}' requires seasonal outputs but "
+            "this model does not use SeasonalMultiTaskLoss; falling back to 'val_loss'."
+        )
 
     # Define checkpoint paths
     best_ckpt_path = Path(output_dir) / f"{experiment_name}.pt"
@@ -2316,8 +2331,6 @@ def run_finetuning(
         fallback_batches = 0
         val_pred_chunks: List[torch.Tensor] = []
         val_target_chunks: List[torch.Tensor] = []
-        seasonal_loss = loss_fn if isinstance(loss_fn, SeasonalMultiTaskLoss) else None
-        seasonal_metrics_supported = seasonal_loss is not None
         seasonal_landcover_records: List[dict[str, Any]] = []
         seasonal_croptype_records: List[dict[str, Any]] = []
         seasonal_gate_rejections = 0
@@ -2573,15 +2586,9 @@ def run_finetuning(
         # --- Early stopping: patience resets only when the monitored metric improves ---
         cur_lc_f1 = seasonal_metrics_flat.get("landcover/f1_macro", -1.0)
         cur_ct_f1 = seasonal_metrics_flat.get("croptype/f1_macro", -1.0)
-        cur_mean_f1 = (cur_lc_f1 + cur_ct_f1) / 2.0
-
-        # F1-based metrics require seasonal outputs; fall back to val_loss for
-        # non-seasonal models where seasonal_metrics_flat is always empty.
-        _effective_metric = (
-            checkpoint_metric
-            if checkpoint_metric == "val_loss" or seasonal_metrics_supported
-            else "val_loss"
-        )
+        # Clamp -1.0 sentinel (metric unavailable, e.g. all CT samples gate-rejected)
+        # to 0.0 so the mean is not pulled negative when one head has no data.
+        cur_mean_f1 = (max(0.0, cur_lc_f1) + max(0.0, cur_ct_f1)) / 2.0
 
         if _effective_metric == "lc_f1":
             loss_improved = best_lc_f1 is None or cur_lc_f1 > best_lc_f1

--- a/src/worldcereal/train/finetuning_utils.py
+++ b/src/worldcereal/train/finetuning_utils.py
@@ -665,7 +665,10 @@ def plot_spatial_predictions(
         linewidths=0.0,
         zorder=3,
     )
-    print(f"{task_name}: plotted spatial hexbin with gridsize={gridsize}, min_count={min_count}, "f"accuracy={acc:.3f}, n={n_total}")
+    logger.info(
+        f"{task_name}: plotted spatial hexbin with gridsize={gridsize}, min_count={min_count}, "
+        f"accuracy={acc:.3f}, n={n_total}"
+    )
 
     cb = fig.colorbar(hb, ax=ax, fraction=0.025, pad=0.02)
     cb.set_label("Local accuracy", fontsize=9)

--- a/src/worldcereal/train/finetuning_utils.py
+++ b/src/worldcereal/train/finetuning_utils.py
@@ -2088,6 +2088,7 @@ def run_finetuning(
     on_validation_improved: Optional[ValidationImprovementCallback] = None,
     tensorboard_logdir: Optional[Union[Path, str]] = None,
     model_ema_alpha: float = 0.0,
+    checkpoint_metric: Literal["val_loss", "lc_f1", "ct_f1", "mean_f1"] = "mean_f1",
 ):
     """Perform the training loop for fine-tuning a model.
 
@@ -2107,6 +2108,9 @@ def run_finetuning(
     train_loss = []
     val_loss = []
     best_loss = None
+    best_ct_f1: Optional[float] = None
+    best_lc_f1: Optional[float] = None
+    best_mean_f1: Optional[float] = None
     best_model_dict = None
     epochs_since_improvement = 0
     ema_model: Optional[torch.nn.Module] = (
@@ -2566,17 +2570,45 @@ def run_finetuning(
                 f"Failed to append validation metrics history at epoch {epoch + 1}: {exc}"
             )
 
-        # --- Early stopping: patience resets only when loss improves ---
-        loss_improved = best_loss is None or current_val_loss < best_loss
+        # --- Early stopping: patience resets only when the monitored metric improves ---
         cur_lc_f1 = seasonal_metrics_flat.get("landcover/f1_macro", -1.0)
         cur_ct_f1 = seasonal_metrics_flat.get("croptype/f1_macro", -1.0)
+        cur_mean_f1 = (cur_lc_f1 + cur_ct_f1) / 2.0
+
+        if checkpoint_metric == "lc_f1":
+            loss_improved = best_lc_f1 is None or cur_lc_f1 > best_lc_f1
+        elif checkpoint_metric == "ct_f1":
+            loss_improved = best_ct_f1 is None or cur_ct_f1 > best_ct_f1
+        elif checkpoint_metric == "mean_f1":
+            loss_improved = best_mean_f1 is None or cur_mean_f1 > best_mean_f1
+        else:
+            loss_improved = best_loss is None or current_val_loss < best_loss
 
         if loss_improved:
             best_loss = current_val_loss
+            best_lc_f1 = cur_lc_f1
+            best_ct_f1 = cur_ct_f1
+            best_mean_f1 = cur_mean_f1
             epochs_since_improvement = 0
-            logger.info(
-                f"Epoch {epoch + 1}: val loss improved to {current_val_loss:.4f}"
-            )
+            if checkpoint_metric == "lc_f1":
+                logger.info(
+                    f"Epoch {epoch + 1}: val LC F1 improved to {cur_lc_f1:.4f} "
+                    f"(val_loss={current_val_loss:.4f})"
+                )
+            elif checkpoint_metric == "ct_f1":
+                logger.info(
+                    f"Epoch {epoch + 1}: val CT F1 improved to {cur_ct_f1:.4f} "
+                    f"(val_loss={current_val_loss:.4f})"
+                )
+            elif checkpoint_metric == "mean_f1":
+                logger.info(
+                    f"Epoch {epoch + 1}: val mean F1 improved to {cur_mean_f1:.4f} "
+                    f"(lc={cur_lc_f1:.4f}, ct={cur_ct_f1:.4f}, val_loss={current_val_loss:.4f})"
+                )
+            else:
+                logger.info(
+                    f"Epoch {epoch + 1}: val loss improved to {current_val_loss:.4f}"
+                )
         else:
             epochs_since_improvement += 1
             if epochs_since_improvement >= hyperparams.patience:
@@ -2614,8 +2646,9 @@ def run_finetuning(
             setattr(_ckpt_model, "_last_validation_context", validation_context)
 
             # best_loss is guaranteed non-None here: on the first epoch
-            # best_loss is None → loss_improved is True → best_loss is set
-            # before we ever reach this block.
+            # loss_improved is always True so best_loss is set before this block.
+            # For all checkpoint_metric values, best_loss is always updated from
+            # current_val_loss above, so the assert holds either way.
             assert best_loss is not None
 
             if on_validation_improved is not None:
@@ -2632,11 +2665,21 @@ def run_finetuning(
         _f1_str = ""
         if cur_lc_f1 > 0 or cur_ct_f1 > 0:
             _f1_str = f" | F1 lc={cur_lc_f1:.3f} ct={cur_ct_f1:.3f}"
+        if checkpoint_metric == "lc_f1":
+            _best_str = f"{best_lc_f1:.3f} (lc_f1)" if best_lc_f1 is not None else "n/a"
+        elif checkpoint_metric == "ct_f1":
+            _best_str = f"{best_ct_f1:.3f} (ct_f1)" if best_ct_f1 is not None else "n/a"
+        elif checkpoint_metric == "mean_f1":
+            _best_str = (
+                f"{best_mean_f1:.3f} (mean_f1)" if best_mean_f1 is not None else "n/a"
+            )
+        else:
+            _best_str = f"{best_loss:.4f}" if best_loss is not None else "n/a"
         description = (
             f"Epoch {epoch + 1}/{hyperparams.max_epochs} | "
             f"Train Loss: {train_loss[-1]:.4f} | "
             f"Val Loss: {_val_loss_str} | "
-            f"Best: {best_loss:.4f}{_f1_str}"
+            f"Best: {_best_str}{_f1_str}"
         )
 
         description += (

--- a/tests/worldcerealtests/test_datasets.py
+++ b/tests/worldcerealtests/test_datasets.py
@@ -2031,5 +2031,165 @@ class TestSmoothedPerBinClassWeights(unittest.TestCase):
             )
 
 
+class TestClassWeightMultipliersRouting(unittest.TestCase):
+    """Tests for class_weight_multipliers routing in DualHeadBatchSampler."""
+
+    def setUp(self):
+        import pandas as pd
+
+        # Shared label that appears in BOTH LC and CT columns — the real-world
+        # example is "temporary_crops" which lives in both LC_CODES and
+        # class_mappings.json.
+        shared = "shared_class"
+        data = {
+            "landcover_label": [shared, "lc_only", shared, "lc_only", shared],
+            "croptype_label": [shared, shared, "ct_only", "ct_only", shared],
+            "lat": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "lon": [1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+        self.df = pd.DataFrame(data)
+
+    def _make_sampler(self, multipliers):
+        from worldcereal.train.datasets import DualHeadBatchSampler
+
+        return DualHeadBatchSampler(
+            dataframe=self.df,
+            batch_size=4,
+            class_weight_method="balanced",
+            num_batches=5,
+            class_weight_multipliers=multipliers,
+        )
+
+    def test_shared_label_applied_to_both_pools(self):
+        """A label present in both LC and CT sets must boost both sampling pools."""
+        sampler_base = self._make_sampler(None)
+        sampler_boost = self._make_sampler({"shared_class": 10.0})
+
+        # LC probs for samples with the shared label should be higher after boost
+        lc_probs_base = sampler_base._lc_probs.numpy()
+        lc_probs_boost = sampler_boost._lc_probs.numpy()
+        ct_probs_base = sampler_base._ct_probs.numpy()
+        ct_probs_boost = sampler_boost._ct_probs.numpy()
+
+        shared_lc_idx = [
+            i
+            for i, v in enumerate(self.df["landcover_label"])
+            if v == "shared_class"
+        ]
+        shared_ct_idx = [
+            i
+            for i, v in enumerate(
+                self.df.loc[self.df["croptype_label"].notna(), "croptype_label"].reset_index(
+                    drop=True
+                )
+            )
+            if v == "shared_class"
+        ]
+
+        # Both pools should have higher probability after the boost
+        self.assertTrue(
+            all(
+                lc_probs_boost[i] > lc_probs_base[i] for i in shared_lc_idx
+            ),
+            "shared_class boost did NOT increase LC pool probabilities",
+        )
+        self.assertTrue(
+            all(
+                ct_probs_boost[i] > ct_probs_base[i] for i in shared_ct_idx
+            ),
+            "shared_class boost did NOT increase CT pool probabilities — elif bug",
+        )
+
+    def test_lc_only_label_only_affects_lc_pool(self):
+        """A label that only exists in the LC pool must not change CT probs."""
+        sampler_base = self._make_sampler(None)
+        sampler_boost = self._make_sampler({"lc_only": 5.0})
+        import numpy as np
+
+        self.assertTrue(
+            np.allclose(
+                sampler_base._ct_probs.numpy(), sampler_boost._ct_probs.numpy()
+            ),
+            "lc_only multiplier incorrectly changed CT pool probabilities",
+        )
+
+    def test_unknown_label_warns_and_does_not_crash(self):
+        """An unknown key in class_weight_multipliers should warn but not raise."""
+        # Should complete without error (warning is logged internally)
+        sampler = self._make_sampler({"completely_unknown_label": 2.0})
+        self.assertIsNotNone(sampler)
+
+
+class TestCheckpointMetricMonitoring(unittest.TestCase):
+    """Tests for the checkpoint_metric / mean_f1 sentinel behavior."""
+
+    def _compute_mean_f1(self, cur_lc_f1, cur_ct_f1):
+        """Replicate the fixed formula from finetuning_utils.py."""
+        return (max(0.0, cur_lc_f1) + max(0.0, cur_ct_f1)) / 2.0
+
+    def test_mean_f1_both_available(self):
+        """mean_f1 is the arithmetic mean when both heads have valid metrics."""
+        result = self._compute_mean_f1(0.8, 0.6)
+        self.assertAlmostEqual(result, 0.7)
+
+    def test_mean_f1_ct_sentinel_does_not_go_negative(self):
+        """When CT is gate-rejected (sentinel -1.0), mean_f1 must stay >= 0."""
+        result = self._compute_mean_f1(0.85, -1.0)
+        self.assertGreaterEqual(result, 0.0)
+        self.assertAlmostEqual(result, 0.425)
+
+    def test_mean_f1_lc_sentinel_does_not_go_negative(self):
+        """When LC sentinel fires, mean_f1 must stay >= 0."""
+        result = self._compute_mean_f1(-1.0, 0.70)
+        self.assertGreaterEqual(result, 0.0)
+        self.assertAlmostEqual(result, 0.35)
+
+    def test_mean_f1_both_sentinel_is_zero(self):
+        """When both heads return sentinel, mean_f1 should be 0.0 (not -1.0)."""
+        result = self._compute_mean_f1(-1.0, -1.0)
+        self.assertEqual(result, 0.0)
+
+    def test_non_seasonal_fallback_to_val_loss(self):
+        """Non-seasonal models must fall back to val_loss regardless of requested metric."""
+        seasonal_metrics_supported = False
+        for requested in ("lc_f1", "ct_f1", "mean_f1"):
+            effective = (
+                requested
+                if requested == "val_loss" or seasonal_metrics_supported
+                else "val_loss"
+            )
+            self.assertEqual(
+                effective,
+                "val_loss",
+                f"checkpoint_metric='{requested}' should fall back to 'val_loss' "
+                "for non-seasonal models",
+            )
+
+    def test_seasonal_model_respects_requested_metric(self):
+        """Seasonal models must use the requested metric without fallback."""
+        seasonal_metrics_supported = True
+        for requested in ("lc_f1", "ct_f1", "mean_f1", "val_loss"):
+            effective = (
+                requested
+                if requested == "val_loss" or seasonal_metrics_supported
+                else "val_loss"
+            )
+            self.assertEqual(
+                effective,
+                requested,
+                f"checkpoint_metric='{requested}' should NOT be overridden for seasonal models",
+            )
+
+    def test_val_loss_explicit_never_falls_back(self):
+        """val_loss always passes through regardless of seasonal support."""
+        for seasonal in (True, False):
+            effective = (
+                "val_loss"
+                if "val_loss" == "val_loss" or seasonal
+                else "val_loss"
+            )
+            self.assertEqual(effective, "val_loss")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Add `class_weight_multipliers` and `checkpoint_metric` to finetuning utilities

### Summary

Two new knobs for dual-head finetuning, plus a ruff formatting pass over `datasets.py`.

---

### Changes

#### `datasets.py` — per-class weight multipliers

A new optional `class_weight_multipliers: Optional[Mapping[str, float]]` parameter is added to both `DualHeadBatchSampler.__init__()` and `WorldCerealLabelledDataset.get_dual_head_batch_sampler()`.

The dict accepts class labels from **either** the LC or CT label space. Routing is automatic: at construction time the sampler compares each key against the observed LC and CT label sets and applies multipliers to the correct pool. Unknown keys produce a warning and are ignored. This avoids the need for two separate arguments and keeps the interface label-space-agnostic.

The multipliers are applied **after** the main class-balancing weights (global or per-bin), so they compose multiplicatively on top of whatever balancing scheme is already in use.

#### finetuning_utils.py — flexible checkpoint metric

A new `checkpoint_metric: Literal["val_loss", "lc_f1", "ct_f1", "mean_f1"]` parameter (default `"val_loss"`) is added to `run_finetuning()`. It controls which metric drives early stopping and best-checkpoint selection:

| value | behaviour |
|---|---|
| `val_loss` | save when total validation loss decreases (previous behaviour) |
| `lc_f1` | save when validation landcover macro F1 increases |
| `ct_f1` | save when validation crop-type macro F1 increases |
| `mean_f1` | **(new default)** save when the average of LC and CT macro F1 increases |

`best_loss` is always kept in sync regardless of the chosen metric, so existing callbacks and `_save_best` continue to receive a valid loss value.

#### Formatting

`datasets.py` received a ruff formatting pass (argument lists reflowed to one-per-line, no logic changes).