### PR TITLE
ensure grid size none is parsed correctly

### DIFF
--- a/scripts/inference/run_worldcereal_task_openeo.py
+++ b/scripts/inference/run_worldcereal_task_openeo.py
@@ -121,6 +121,12 @@ def _validate_classification_flags(
     return enable_cropland_head, enable_croptype_head, enforce_cropland_gate
 
 
+def _parse_optional_int(value: str) -> Optional[int]:
+    if value.lower() == "none":
+        return None
+    return int(value)
+
+
 def main(task: WorldCerealTask, params: WorldCerealJobParams) -> None:
     run_worldcereal_task(task, dict(params))
 
@@ -160,9 +166,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--grid_size",
-        type=int,
+        type=_parse_optional_int,
         default=20,
-        help="Tile size in kilometers for splitting AOIs. If not specified, the original AOI geometries will be used.",
+        help="Tile size in kilometers for splitting AOIs. Use 'none' to use original geometries.",
     )
     parser.add_argument(
         "--start_date",

--- a/src/worldcereal/job_params.py
+++ b/src/worldcereal/job_params.py
@@ -287,10 +287,14 @@ def resolve_job_params(
     poll_sleep_default = 60
     backend_context_default = BackendContext(Backend.CDSE)
 
+    # Keep explicit None for grid_size (e.g. --grid_size none) to skip tiling,
+    # while still defaulting to 20 when the key is omitted.
+    grid_size = params["grid_size"] if "grid_size" in params else grid_size_default
+
     resolved: Dict[str, Any] = {
         "aoi_gdf": aoi_gdf,
         "output_dir": output_dir,
-        "grid_size": _with_default(params.get("grid_size"), grid_size_default),
+        "grid_size": grid_size,
         "temporal_extent": params.get("temporal_extent"),
         "year": params.get("year"),
         "s1_orbit_state": params.get("s1_orbit_state"),


### PR DESCRIPTION
starting production from an existing production grid was bugged as setting grid_size == None was currently not supported