### PR TITLE
Consistent season-window date handling (fixes silent in-season sample drops)

### DIFF
--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -47,7 +47,7 @@ from worldcereal.train import (
 from worldcereal.train import predictors as _predictor_utils
 from worldcereal.train.seasonal import (
     SeasonWindow,
-    _coerce_date_for_year,
+    coerce_date_for_year,
     align_to_composite_window,
     date_in_season,
     enumerate_composite_slots,
@@ -1561,9 +1561,9 @@ class WorldCerealDataset(Dataset):
 
         cycles: List[Tuple[np.datetime64, np.datetime64]] = []
         for year in sorted(base_years):
-            start_dt = _coerce_date_for_year(year, window.start_month, window.start_day)
+            start_dt = coerce_date_for_year(year, window.start_month, window.start_day)
             end_year = year + window.year_offset
-            end_dt = _coerce_date_for_year(end_year, window.end_month, window.end_day)
+            end_dt = coerce_date_for_year(end_year, window.end_month, window.end_day)
             start_aligned = align_to_composite_window(start_dt, self.timestep_freq)
             end_aligned = align_to_composite_window(end_dt, self.timestep_freq)
             if end_aligned < start_aligned:

--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -1,4 +1,3 @@
-import calendar
 import re
 from collections import Counter
 from contextlib import nullcontext
@@ -46,7 +45,15 @@ from worldcereal.train import (
     SEASONALITY_LOOKUP_PATH,
 )
 from worldcereal.train import predictors as _predictor_utils
-from worldcereal.train.seasonal import align_to_composite_window
+from worldcereal.train.seasonal import (
+    SeasonWindow,
+    _coerce_date_for_year,
+    align_to_composite_window,
+    date_in_season,
+    enumerate_composite_slots,
+    in_season_window,
+    season_window_from_dates,
+)
 
 # Re-export helper functions so legacy imports remain valid.
 generate_predictor = _predictor_utils.generate_predictor
@@ -66,15 +73,6 @@ def _seasonality_lookup_context():
     if SEASONALITY_LOOKUP_PATH.exists():
         return nullcontext(SEASONALITY_LOOKUP_PATH)
     return resources.path(SEASONALITY_LOOKUP_PACKAGE, SEASONALITY_LOOKUP_FILENAME)
-
-
-@dataclass(frozen=True)
-class SeasonWindow:
-    start_month: int
-    start_day: int
-    end_month: int
-    end_day: int
-    year_offset: int = 0
 
 
 def _is_lc_only_dataset(ref_id: str) -> bool:
@@ -206,14 +204,6 @@ def _resolve_season_engine(
     raise ValueError(f"Unknown season_calendar_mode: {mode}")
 
 
-def _coerce_date_for_year(year: int, month: int, day: int) -> np.datetime64:
-    """Build a numpy datetime64, clamping the day to the month's max if needed."""
-
-    last_day = calendar.monthrange(year, month)[1]
-    safe_day = min(day, last_day)
-    return np.datetime64(f"{year:04d}-{month:02d}-{safe_day:02d}", "D")
-
-
 def _normalize_season_windows(
     season_windows: Optional[Mapping[str, Tuple[Any, Any]]],
 ) -> Dict[str, SeasonWindow]:
@@ -242,30 +232,10 @@ def _normalize_season_windows(
 
         start_np = start_dt.astype("datetime64[D]")
         end_np = end_dt.astype("datetime64[D]")
-        if end_np < start_np:
-            raise ValueError(
-                f"Season window for '{season}' has end date {end_dt} before start date {start_dt}."
-            )
-
-        start_ts = pd.Timestamp(start_np)
-        end_ts = pd.Timestamp(end_np)
-        year_offset = end_ts.year - start_ts.year
-        if year_offset < 0:
-            raise ValueError(
-                f"Season window for '{season}' has end date {end_dt} before start date {start_dt}."
-            )
-        if year_offset > 1:
-            raise ValueError(
-                f"Season window for '{season}' spans more than one year; only single-year crossings are supported."
-            )
-
-        normalized[season] = SeasonWindow(
-            start_month=start_ts.month,
-            start_day=start_ts.day,
-            end_month=end_ts.month,
-            end_day=end_ts.day,
-            year_offset=year_offset,
-        )
+        try:
+            normalized[season] = season_window_from_dates(start_np, end_np)
+        except ValueError as exc:
+            raise ValueError(f"Season window for '{season}': {exc}") from exc
 
     return normalized
 
@@ -286,42 +256,12 @@ def _label_datetime_series(frame: pd.DataFrame) -> pd.Series:
     return result
 
 
-def _timestamp_in_season_window(
-    timestamp: Optional[pd.Timestamp],
-    *,
-    window: SeasonWindow,
-) -> bool:
-    if timestamp is None or pd.isna(timestamp):
-        return False
-
-    ts = pd.Timestamp(timestamp)
-
-    if window.year_offset not in (0, 1):
-        raise ValueError("Season windows must span at most 12 months.")
-
-    if window.year_offset == 0:
-        start_year = ts.year
-    else:
-        ts_tuple = (ts.month, ts.day)
-        end_tuple = (window.end_month, window.end_day)
-        start_year = ts.year if ts_tuple > end_tuple else ts.year - 1
-
-    start_dt = pd.Timestamp(
-        _coerce_date_for_year(start_year, window.start_month, window.start_day)
-    )
-    end_dt = pd.Timestamp(
-        _coerce_date_for_year(
-            start_year + window.year_offset, window.end_month, window.end_day
-        )
-    )
-    return start_dt <= ts <= end_dt
-
-
 def _filter_frame_by_manual_windows(
     dataframe: pd.DataFrame,
     season_windows: Mapping[str, SeasonWindow],
     *,
     context: str,
+    timestep_freq: Literal["month", "dekad"],
 ) -> Tuple[pd.DataFrame, int]:
     if not season_windows:
         return dataframe, 0
@@ -337,7 +277,8 @@ def _filter_frame_by_manual_windows(
     keep_mask = pd.Series(False, index=dataframe.index, dtype=bool)
     for season_name, window in season_windows.items():
         keep_mask |= label_datetimes.apply(
-            lambda ts: _timestamp_in_season_window(ts, window=window)
+            lambda ts, w=window: pd.notna(ts)
+            and in_season_window(ts, w, freq=timestep_freq)
         )
 
     missing = label_datetimes.isna().sum()
@@ -1627,7 +1568,9 @@ class WorldCerealDataset(Dataset):
             end_aligned = align_to_composite_window(end_dt, self.timestep_freq)
             if end_aligned < start_aligned:
                 continue
-            slots = self._enumerate_composite_slots(start_aligned, end_aligned)
+            slots = enumerate_composite_slots(
+                start_aligned, end_aligned, self.timestep_freq
+            )
             if not slots:
                 continue
             cycle_mask = (composite_dates >= start_aligned) & (
@@ -1636,15 +1579,16 @@ class WorldCerealDataset(Dataset):
             n_required = max(1, round(len(slots) * self.min_season_coverage))
             if int(cycle_mask.sum()) < n_required:
                 continue
-            cycles.append((start_aligned, end_aligned))
+            # Store the raw cycle bounds so the in_season check can compare the
+            # exact label against composite-aligned edges (date_in_season),
+            # consistent with the season-alignment pre-filter and the mask.
+            cycles.append((start_dt, end_dt))
             mask |= cycle_mask
 
-        in_flag = False
-        if label_datetime is not None:
-            for start_aligned, end_aligned in cycles:
-                if start_aligned <= label_datetime <= end_aligned:
-                    in_flag = True
-                    break
+        in_flag = label_datetime is not None and any(
+            date_in_season(label_datetime, start_dt, end_dt, freq=self.timestep_freq)
+            for start_dt, end_dt in cycles
+        )
 
         return mask.astype(bool, copy=False), in_flag
 
@@ -1688,7 +1632,9 @@ class WorldCerealDataset(Dataset):
 
         start_aligned = align_to_composite_window(start_dt, self.timestep_freq)
         end_aligned = align_to_composite_window(end_dt, self.timestep_freq)
-        slots = self._enumerate_composite_slots(start_aligned, end_aligned)
+        slots = enumerate_composite_slots(
+            start_aligned, end_aligned, self.timestep_freq
+        )
         partial_mask = (composite_dates >= start_aligned) & (
             composite_dates <= end_aligned
         )
@@ -1700,44 +1646,12 @@ class WorldCerealDataset(Dataset):
             else np.zeros_like(composite_dates, dtype=bool)
         )
         in_flag = (
-            bool(start_dt <= label_datetime <= end_dt)
+            date_in_season(label_datetime, start_dt, end_dt, freq=self.timestep_freq)
             if (label_datetime is not None and meets_threshold)
             else False
         )
         return mask.astype(bool, copy=False), in_flag
 
-    def _enumerate_composite_slots(
-        self, start: np.datetime64, end: np.datetime64
-    ) -> List[np.datetime64]:
-        if end < start:
-            return []
-        slots: List[np.datetime64] = []
-        current = start
-        while True:
-            slots.append(current)
-            if current >= end:
-                break
-            current = self._advance_composite_slot(current)
-        return slots
-
-    def _advance_composite_slot(self, current: np.datetime64) -> np.datetime64:
-        current = current.astype("datetime64[D]")
-        if self.timestep_freq == "month":
-            month_step = current.astype("datetime64[M]") + np.timedelta64(1, "M")
-            return month_step.astype("datetime64[D]")
-        if self.timestep_freq == "dekad":
-            month_start = current.astype("datetime64[M]")
-            # Offset from first day determines which dekad we are in.
-            offset_days = (current - month_start).astype(int)
-            if offset_days == 0:
-                return current + np.timedelta64(10, "D")
-            if offset_days == 10:
-                return current + np.timedelta64(10, "D")
-            if offset_days == 20:
-                next_month = month_start + np.timedelta64(1, "M")
-                return next_month.astype("datetime64[D]")
-            raise ValueError("Dekad slots must align to days 1, 11, or 21.")
-        raise ValueError(f"Unknown timestep frequency '{self.timestep_freq}'")
 
     def _season_context_for(
         self,
@@ -1901,6 +1815,7 @@ class WorldCerealLabelledDataset(WorldCerealDataset):
                 self.dataframe,
                 self._season_windows,
                 context=self.__class__.__name__,
+                timestep_freq=self.timestep_freq,
             )
             if dropped:
                 logger.info(
@@ -2534,6 +2449,7 @@ class WorldCerealTrainingDataset(WorldCerealDataset):
                 self.dataframe,
                 self._season_windows,
                 context=self.__class__.__name__,
+                timestep_freq=self.timestep_freq,
             )
             if dropped:
                 logger.info(

--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -47,8 +47,8 @@ from worldcereal.train import (
 from worldcereal.train import predictors as _predictor_utils
 from worldcereal.train.seasonal import (
     SeasonWindow,
-    coerce_date_for_year,
     align_to_composite_window,
+    coerce_date_for_year,
     date_in_season,
     enumerate_composite_slots,
     in_season_window,
@@ -277,8 +277,9 @@ def _filter_frame_by_manual_windows(
     keep_mask = pd.Series(False, index=dataframe.index, dtype=bool)
     for season_name, window in season_windows.items():
         keep_mask |= label_datetimes.apply(
-            lambda ts, w=window: pd.notna(ts)
-            and in_season_window(ts, w, freq=timestep_freq)
+            lambda ts, w=window: (
+                pd.notna(ts) and in_season_window(ts, w, freq=timestep_freq)
+            )
         )
 
     missing = label_datetimes.isna().sum()
@@ -1652,7 +1653,6 @@ class WorldCerealDataset(Dataset):
         )
         return mask.astype(bool, copy=False), in_flag
 
-
     def _season_context_for(
         self,
         season_id: str,
@@ -2291,9 +2291,7 @@ class DualHeadBatchSampler(Sampler):
                     for reg, cmults in mults_canonical.items()
                 }
                 applied = {k: v for k, v in applied.items() if v}
-                logger.info(
-                    f"Applied {pool_name} class weight multipliers: {applied}"
-                )
+                logger.info(f"Applied {pool_name} class weight multipliers: {applied}")
                 return class_arr * mult_arr
 
             lc_class_arr = _apply(

--- a/src/worldcereal/train/seasonal.py
+++ b/src/worldcereal/train/seasonal.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import calendar
 from dataclasses import dataclass
-from typing import Literal, Tuple
+from typing import List, Literal, Tuple
 
 import numpy as np
 import pandas as pd
@@ -91,6 +91,25 @@ def composite_window_end(
     """
 
     return advance_composite_slot(dt_in, timestep_freq) - np.timedelta64(1, "D")
+
+
+def enumerate_composite_slots(
+    start: np.datetime64, end: np.datetime64, timestep_freq: CompositeFreq
+) -> List[np.datetime64]:
+    """List the composite-window starts from ``start`` to ``end`` (inclusive).
+
+    Both bounds are expected to be composite-aligned (see
+    `align_to_composite_window`). Returns an empty list when ``end < start``.
+    """
+
+    if end < start:
+        return []
+    slots: List[np.datetime64] = [start]
+    current = start
+    while current < end:
+        current = advance_composite_slot(current, timestep_freq)
+        slots.append(current)
+    return slots
 
 
 def _as_day(value: DateLike) -> np.datetime64:

--- a/src/worldcereal/train/seasonal.py
+++ b/src/worldcereal/train/seasonal.py
@@ -120,7 +120,7 @@ def _as_day(value: DateLike) -> np.datetime64:
     return np.datetime64(pd.Timestamp(value), "D")
 
 
-def _coerce_date_for_year(year: int, month: int, day: int) -> np.datetime64:
+def coerce_date_for_year(year: int, month: int, day: int) -> np.datetime64:
     """Build a numpy datetime64, clamping the day to the month's max if needed."""
 
     last_day = calendar.monthrange(year, month)[1]
@@ -174,8 +174,8 @@ def resolve_season_bounds(
         after_end = (ref.month, ref.day) > (window.end_month, window.end_day)
         start_year = ref.year if after_end else ref.year - 1
 
-    start = _coerce_date_for_year(start_year, window.start_month, window.start_day)
-    end = _coerce_date_for_year(
+    start = coerce_date_for_year(start_year, window.start_month, window.start_day)
+    end = coerce_date_for_year(
         start_year + window.year_offset, window.end_month, window.end_day
     )
     return start, end

--- a/src/worldcereal/train/seasonal.py
+++ b/src/worldcereal/train/seasonal.py
@@ -2,9 +2,35 @@
 
 from __future__ import annotations
 
-from typing import Literal
+import calendar
+from dataclasses import dataclass
+from typing import Literal, Tuple
 
 import numpy as np
+import pandas as pd
+
+CompositeFreq = Literal["month", "dekad"]
+
+# Anything that can be normalized to a calendar date: a numpy datetime64, a
+# pandas Timestamp, a python datetime/date, or an ISO date string.
+DateLike = object
+
+
+@dataclass(frozen=True)
+class SeasonWindow:
+    """Month/day extent of a season, applied per year.
+
+    ``year_offset`` is 0 for in-year seasons and 1 when the window crosses the
+    year boundary (e.g. Nov -> Mar). Days that do not exist in a given month/year are
+    clamped to the month's last day when the window is resolved to a concrete
+    date (see `resolve_season_bounds`).
+    """
+
+    start_month: int
+    start_day: int
+    end_month: int
+    end_day: int
+    year_offset: int = 0
 
 
 def align_to_composite_window(
@@ -30,3 +56,147 @@ def align_to_composite_window(
         raise ValueError(f"Unknown compositing window: {timestep_freq}")
 
     return correct_date
+
+
+def advance_composite_slot(
+    dt_in: np.datetime64, timestep_freq: CompositeFreq
+) -> np.datetime64:
+    """Return the start of the composite window immediately after ``dt_in``'s.
+    This is the single source of truth for advancing one composite slot
+    (month or dekad).
+    """
+
+    start = align_to_composite_window(dt_in, timestep_freq).astype("datetime64[D]")
+    if timestep_freq == "month":
+        return (start.astype("datetime64[M]") + np.timedelta64(1, "M")).astype(
+            "datetime64[D]"
+        )
+    if timestep_freq == "dekad":
+        offset_days = int((start - start.astype("datetime64[M]")).astype(int))  # 0/10/20
+        if offset_days in (0, 10):
+            return start + np.timedelta64(10, "D")
+        return (start.astype("datetime64[M]") + np.timedelta64(1, "M")).astype(
+            "datetime64[D]"
+        )
+    raise ValueError(f"Unknown compositing window: {timestep_freq}")
+
+
+def composite_window_end(
+    dt_in: np.datetime64, timestep_freq: CompositeFreq
+) -> np.datetime64:
+    """Return the inclusive END date of the composite window containing ``dt_in``.
+
+    End-edge counterpart to `align_to_composite_window` (the start edge): together
+    they bracket one slot (month: 1st <-> last day; dekad: 1/11/21 <-> 10/20/last).
+    """
+
+    return advance_composite_slot(dt_in, timestep_freq) - np.timedelta64(1, "D")
+
+
+def _as_day(value: DateLike) -> np.datetime64:
+    """Normalize any date-like value to ``datetime64[D]``."""
+
+    if isinstance(value, np.datetime64):
+        return value.astype("datetime64[D]")
+    return np.datetime64(pd.Timestamp(value), "D")
+
+
+def _coerce_date_for_year(year: int, month: int, day: int) -> np.datetime64:
+    """Build a numpy datetime64, clamping the day to the month's max if needed."""
+
+    last_day = calendar.monthrange(year, month)[1]
+    safe_day = min(day, last_day)
+    return np.datetime64(f"{year:04d}-{month:02d}-{safe_day:02d}", "D")
+
+
+def season_window_from_dates(start: DateLike, end: DateLike) -> SeasonWindow:
+    """Build a :class:`SeasonWindow` from two concrete dates.
+
+    The window spans at most 12 consecutive months; ``year_offset`` is inferred
+    from the two years (0 for in-year, 1 for a single new-year crossing).
+    """
+
+    start_ts = pd.Timestamp(start)
+    end_ts = pd.Timestamp(end)
+    if end_ts < start_ts:
+        raise ValueError(
+            f"Season window end {end_ts.date()} precedes start {start_ts.date()}."
+        )
+    year_offset = end_ts.year - start_ts.year
+    if year_offset > 1:
+        raise ValueError(
+            "Season window may span at most 12 consecutive months "
+            f"(got {start_ts.date()} -> {end_ts.date()})."
+        )
+    return SeasonWindow(
+        start_month=start_ts.month,
+        start_day=start_ts.day,
+        end_month=end_ts.month,
+        end_day=end_ts.day,
+        year_offset=year_offset,
+    )
+
+
+def resolve_season_bounds(
+    reference: DateLike, window: SeasonWindow
+) -> Tuple[np.datetime64, np.datetime64]:
+    """Resolve ``window`` to concrete (start, end) dates for ``reference``'s cycle.
+
+    For year-crossing windows (``year_offset == 1``) the cycle is chosen so that
+    ``reference`` is attributed to the season it most plausibly belongs to: if it
+    falls on/after the window's end month/day it opens the cycle in its own year,
+    otherwise it belongs to the cycle that opened the previous year.
+    """
+
+    ref = pd.Timestamp(reference)
+    if window.year_offset == 0:
+        start_year = ref.year
+    else:
+        after_end = (ref.month, ref.day) > (window.end_month, window.end_day)
+        start_year = ref.year if after_end else ref.year - 1
+
+    start = _coerce_date_for_year(start_year, window.start_month, window.start_day)
+    end = _coerce_date_for_year(
+        start_year + window.year_offset, window.end_month, window.end_day
+    )
+    return start, end
+
+
+def date_in_season(
+    label: DateLike,
+    start: DateLike,
+    end: DateLike,
+    *,
+    freq: CompositeFreq | None = None,
+) -> bool:
+    """Whether ``label`` falls within the ``[start, end]`` season range.
+
+    With ``freq is None`` the comparison is at exact day resolution. With ``freq``
+    set, the season *start* is snapped down to the start of its composite window
+    and the season *end* up to the inclusive end of its composite window, while
+    the label keeps its exact date. This compares exact label datetimes against
+    exact composite-window edges (month or dekad), so a label counts as in-season
+    only when its composite slot is part of the season.
+    """
+
+    label_d = _as_day(label)
+    start_d = _as_day(start)
+    end_d = _as_day(end)
+    if freq is not None:
+        start_d = align_to_composite_window(start_d, freq)
+        end_d = composite_window_end(end_d, freq)
+    return bool(start_d <= label_d <= end_d)
+
+
+def in_season_window(
+    ts: DateLike, window: SeasonWindow, *, freq: CompositeFreq | None = None
+) -> bool:
+    """Whether ``ts`` falls inside ``window`` (optionally composite-aligned).
+
+    Single source of truth for "is this date in the season window?", shared by
+    the season-alignment pre-filter, the manual-window dataset filter, and the
+    ``in_season`` flag, so they can no longer disagree on the boundary.
+    """
+
+    start, end = resolve_season_bounds(ts, window)
+    return date_in_season(ts, start, end, freq=freq)

--- a/src/worldcereal/utils/refdata.py
+++ b/src/worldcereal/utils/refdata.py
@@ -1,4 +1,3 @@
-import calendar
 import glob
 import importlib.resources
 import json
@@ -750,42 +749,6 @@ def get_best_valid_time(
     return np.nan
 
 
-def _season_window_membership(
-    timestamp: Optional[pd.Timestamp],
-    *,
-    start_month: int,
-    start_day: int,
-    end_month: int,
-    end_day: int,
-    year_offset: int,
-) -> bool:
-    if timestamp is None or pd.isna(timestamp):
-        return False
-
-    ts = pd.Timestamp(timestamp)
-
-    def _coerce(year: int, month: int, day: int) -> pd.Timestamp:
-        safe_day = min(day, calendar.monthrange(year, month)[1])
-        return pd.Timestamp(year=year, month=month, day=safe_day)
-
-    if year_offset not in (0, 1):
-        raise ValueError(
-            "season_window only supports spans up to 12 months (year_offset must be 0 or 1)."
-        )
-
-    if year_offset == 0:
-        start_year = ts.year
-    else:
-        ts_tuple = (ts.month, ts.day)
-        end_tuple = (end_month, end_day)
-        start_year = ts.year if ts_tuple > end_tuple else ts.year - 1
-
-    start_dt = _coerce(start_year, start_month, start_day)
-    end_dt = _coerce(start_year + year_offset, end_month, end_day)
-    # Inclusive on both boundaries: samples on start_date and end_date are kept
-    return start_dt <= ts <= end_dt
-
-
 def process_extractions_df(
     df_raw: Union[pd.DataFrame, gpd.GeoDataFrame],
     processing_period: TemporalContext = None,
@@ -832,6 +795,7 @@ def process_extractions_df(
     The function preserves the original 'valid_time' even when samples are aligned to a new temporal context.
     """
 
+    from worldcereal.train.seasonal import in_season_window, season_window_from_dates
     from worldcereal.utils.legend import ewoc_code_to_label
     from worldcereal.utils.timeseries import (
         DataFrameValidator,
@@ -966,13 +930,7 @@ def process_extractions_df(
 
     if season_window is not None:
         season_start, season_end = season_window.to_datetime()
-        if season_end < season_start:
-            raise ValueError(
-                "season_window end date must be greater than or equal to the start date."
-            )
-        year_offset = season_end.year - season_start.year
-        if year_offset < 0 or year_offset > 1:
-            raise ValueError("season_window may span at most 12 consecutive months.")
+        window = season_window_from_dates(season_start, season_end)
 
         valid_times = pd.to_datetime(df_processed["valid_time"], errors="coerce")
         missing_valid = valid_times.isna()
@@ -989,15 +947,11 @@ def process_extractions_df(
                 f"Dropping {int(missing_valid.sum())} samples without a valid_time while enforcing the manual season window:\n{counts_table}"
             )
 
+        # Composite-aware membership: compare the exact valid_time against the
+        # season's composite-window edges (month/dekad), matching the in_season
+        # flag computed later in the dataset so the two stages stay consistent.
         in_window = valid_times.apply(
-            lambda ts: _season_window_membership(
-                ts,
-                start_month=season_start.month,
-                start_day=season_start.day,
-                end_month=season_end.month,
-                end_day=season_end.day,
-                year_offset=year_offset,
-            )
+            lambda ts: pd.notna(ts) and in_season_window(ts, window, freq=freq)
         )
         in_window &= ~missing_valid
 

--- a/tests/worldcerealtests/test_seasonal.py
+++ b/tests/worldcerealtests/test_seasonal.py
@@ -1,0 +1,293 @@
+"""Tests for the shared season-window helpers in ``worldcereal.train.seasonal``.
+
+These cover the composite-grid primitives (start/end edges, slot advance) and
+the season-membership stack (``SeasonWindow`` resolution + ``in_season_window``)
+that unify how dates are compared against a season across the pipeline.
+
+Regression focus: the ``in_season`` flag must agree with the season the user
+asked for at *composite* resolution. A label whose valid_time falls in the final
+month of the window (e.g. Aug 15 for a Feb->Aug season) must count as in-season,
+while staying correct for dekadal compositing (an Aug 31 label must fall out of a
+season that ends in the 2nd dekad of August).
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from worldcereal.train.seasonal import (
+    SeasonWindow,
+    advance_composite_slot,
+    align_to_composite_window,
+    composite_window_end,
+    date_in_season,
+    in_season_window,
+    resolve_season_bounds,
+    season_window_from_dates,
+)
+
+
+def _d(value: str) -> np.datetime64:
+    return np.datetime64(value, "D")
+
+
+# ---------------------------------------------------------------------------
+# Composite-grid primitives
+# ---------------------------------------------------------------------------
+
+
+class TestAlignToCompositeWindow:
+    @pytest.mark.parametrize(
+        "date, expected",
+        [
+            ("2023-08-01", "2023-08-01"),
+            ("2023-08-15", "2023-08-01"),
+            ("2023-08-31", "2023-08-01"),
+            ("2024-02-29", "2024-02-01"),
+        ],
+    )
+    def test_month_snaps_to_first(self, date, expected):
+        assert align_to_composite_window(_d(date), "month") == _d(expected)
+
+    @pytest.mark.parametrize(
+        "date, expected",
+        [
+            ("2023-08-01", "2023-08-01"),  # 1st dekad
+            ("2023-08-10", "2023-08-01"),
+            ("2023-08-11", "2023-08-11"),  # 2nd dekad
+            ("2023-08-20", "2023-08-11"),
+            ("2023-08-21", "2023-08-21"),  # 3rd dekad
+            ("2023-08-31", "2023-08-21"),
+        ],
+    )
+    def test_dekad_snaps_to_slot_start(self, date, expected):
+        assert align_to_composite_window(_d(date), "dekad") == _d(expected)
+
+    def test_unknown_freq_raises(self):
+        with pytest.raises(ValueError):
+            align_to_composite_window(_d("2023-08-15"), "weekly")
+
+
+class TestAdvanceCompositeSlot:
+    @pytest.mark.parametrize(
+        "date, expected",
+        [
+            ("2023-08-15", "2023-09-01"),
+            ("2023-12-15", "2024-01-01"),  # year roll-over
+            ("2024-02-10", "2024-03-01"),
+        ],
+    )
+    def test_month(self, date, expected):
+        assert advance_composite_slot(_d(date), "month") == _d(expected)
+
+    @pytest.mark.parametrize(
+        "date, expected",
+        [
+            ("2023-08-05", "2023-08-11"),  # 1st -> 2nd dekad
+            ("2023-08-15", "2023-08-21"),  # 2nd -> 3rd dekad
+            ("2023-08-25", "2023-09-01"),  # 3rd -> next month
+            ("2023-02-25", "2023-03-01"),  # short month, non-leap
+            ("2024-02-25", "2024-03-01"),  # short month, leap
+        ],
+    )
+    def test_dekad(self, date, expected):
+        assert advance_composite_slot(_d(date), "dekad") == _d(expected)
+
+    def test_accepts_unaligned_input(self):
+        # Unlike the strict dataset method, any date in a slot advances correctly.
+        assert advance_composite_slot(_d("2023-08-17"), "dekad") == _d("2023-08-21")
+
+    def test_unknown_freq_raises(self):
+        with pytest.raises(ValueError):
+            advance_composite_slot(_d("2023-08-15"), "weekly")
+
+
+class TestCompositeWindowEnd:
+    @pytest.mark.parametrize(
+        "date, expected",
+        [
+            ("2023-08-15", "2023-08-31"),
+            ("2023-02-10", "2023-02-28"),  # non-leap February
+            ("2024-02-10", "2024-02-29"),  # leap February
+            ("2023-04-05", "2023-04-30"),
+            ("2023-12-31", "2023-12-31"),
+        ],
+    )
+    def test_month(self, date, expected):
+        assert composite_window_end(_d(date), "month") == _d(expected)
+
+    @pytest.mark.parametrize(
+        "date, expected",
+        [
+            ("2023-08-05", "2023-08-10"),  # 1st dekad ends on the 10th
+            ("2023-08-15", "2023-08-20"),  # 2nd dekad ends on the 20th
+            ("2023-08-25", "2023-08-31"),  # 3rd dekad runs to month end
+            ("2023-02-25", "2023-02-28"),  # 3rd dekad, non-leap
+            ("2024-02-25", "2024-02-29"),  # 3rd dekad, leap
+        ],
+    )
+    def test_dekad(self, date, expected):
+        assert composite_window_end(_d(date), "dekad") == _d(expected)
+
+    def test_is_start_edge_complement(self):
+        # start edge and end edge bracket exactly one slot
+        for date in ("2023-08-05", "2023-08-15", "2023-08-25"):
+            start = align_to_composite_window(_d(date), "dekad")
+            end = composite_window_end(_d(date), "dekad")
+            assert start <= _d(date) <= end
+
+
+# ---------------------------------------------------------------------------
+# SeasonWindow construction & resolution
+# ---------------------------------------------------------------------------
+
+
+class TestSeasonWindowFromDates:
+    def test_in_year(self):
+        assert season_window_from_dates("2023-02-01", "2023-08-31") == SeasonWindow(
+            2, 1, 8, 31, 0
+        )
+
+    def test_year_crossing_sets_offset(self):
+        assert season_window_from_dates("2023-11-01", "2024-03-31") == SeasonWindow(
+            11, 1, 3, 31, 1
+        )
+
+    def test_accepts_timestamps(self):
+        w = season_window_from_dates(
+            pd.Timestamp("2023-02-01"), np.datetime64("2023-08-31")
+        )
+        assert w == SeasonWindow(2, 1, 8, 31, 0)
+
+    def test_end_before_start_raises(self):
+        with pytest.raises(ValueError):
+            season_window_from_dates("2023-08-31", "2023-02-01")
+
+    def test_more_than_one_year_crossing_raises(self):
+        with pytest.raises(ValueError):
+            season_window_from_dates("2022-02-01", "2024-08-31")
+
+
+class TestResolveSeasonBounds:
+    def test_in_year_uses_reference_year(self):
+        w = SeasonWindow(2, 1, 8, 31, 0)
+        start, end = resolve_season_bounds("2023-05-10", w)
+        assert (start, end) == (_d("2023-02-01"), _d("2023-08-31"))
+
+    def test_in_year_independent_of_reference_year(self):
+        w = SeasonWindow(2, 1, 8, 31, 0)
+        start, end = resolve_season_bounds("2020-05-10", w)
+        assert (start, end) == (_d("2020-02-01"), _d("2020-08-31"))
+
+    @pytest.mark.parametrize(
+        "reference, exp_start, exp_end",
+        [
+            ("2024-01-10", "2023-11-01", "2024-03-31"),  # inside the crossing season
+            ("2023-12-15", "2023-11-01", "2024-03-31"),  # before new year
+            ("2024-11-15", "2024-11-01", "2025-03-31"),  # next cycle
+        ],
+    )
+    def test_year_crossing_cycle_selection(self, reference, exp_start, exp_end):
+        w = SeasonWindow(11, 1, 3, 31, 1)
+        start, end = resolve_season_bounds(reference, w)
+        assert (start, end) == (_d(exp_start), _d(exp_end))
+
+    @pytest.mark.parametrize(
+        "ref, expected_end",
+        [("2023-05-01", "2023-02-28"), ("2024-05-01", "2024-02-29")],
+    )
+    def test_invalid_day_is_clamped_to_month_end(self, ref, expected_end):
+        # A Feb-29 boundary clamps to 28/29 depending on the resolved year.
+        w = SeasonWindow(1, 1, 2, 29, 0)
+        _, end = resolve_season_bounds(ref, w)
+        assert end == _d(expected_end)
+
+
+# ---------------------------------------------------------------------------
+# Membership: date_in_season / in_season_window
+# ---------------------------------------------------------------------------
+
+
+class TestDateInSeasonDayResolution:
+    """freq=None keeps exact day-resolution, inclusive on both ends."""
+
+    @pytest.mark.parametrize(
+        "label, expected",
+        [
+            ("2023-02-01", True),  # inclusive start
+            ("2023-08-31", True),  # inclusive end
+            ("2023-01-31", False),
+            ("2023-09-01", False),
+        ],
+    )
+    def test_exact_bounds(self, label, expected):
+        assert date_in_season(label, "2023-02-01", "2023-08-31") is expected
+
+
+class TestDateInSeasonComposite:
+    def test_month_end_rounds_up_to_month(self):
+        # season end Aug 15 -> whole August in-season at month resolution
+        assert date_in_season("2023-08-31", "2023-02-10", "2023-08-15", freq="month")
+        assert not date_in_season(
+            "2023-09-01", "2023-02-10", "2023-08-15", freq="month"
+        )
+
+    def test_month_start_rounds_down_to_month(self):
+        # season start Feb 10 -> all of February in-season
+        assert date_in_season("2023-02-01", "2023-02-10", "2023-08-15", freq="month")
+
+    @pytest.mark.parametrize(
+        "label, expected",
+        [
+            ("2023-08-20", True),  # last day of the end dekad is still in
+            ("2023-08-21", False),  # the next dekad is out
+        ],
+    )
+    def test_dekad_end_edge_rounds_up(self, label, expected):
+        # season ends Aug 12, in the 2nd dekad of August -> snaps up to Aug 20
+        assert (
+            date_in_season(label, "2023-02-01", "2023-08-12", freq="dekad") is expected
+        )
+
+    @pytest.mark.parametrize(
+        "label, expected",
+        [
+            ("2023-08-11", True),  # first day of the start dekad is in
+            ("2023-08-10", False),  # the previous dekad is out
+        ],
+    )
+    def test_dekad_start_edge_rounds_down(self, label, expected):
+        # season starts Aug 12, in the 2nd dekad of August -> snaps down to Aug 11
+        assert (
+            date_in_season(label, "2023-08-12", "2023-12-31", freq="dekad") is expected
+        )
+
+
+class TestInSeasonWindow:
+    @pytest.mark.parametrize(
+        "label, expected",
+        [
+            ("2023-11-15", True),
+            ("2024-01-10", True),
+            ("2024-03-15", True),
+            ("2023-10-20", False),
+            ("2024-04-05", False),
+        ],
+    )
+    def test_year_crossing_membership(self, label, expected):
+        w = season_window_from_dates("2023-11-01", "2024-03-31")
+        assert in_season_window(label, w, freq="month") is expected
+
+    @pytest.mark.parametrize(
+        "label",
+        ["2023-08-15", pd.Timestamp("2023-08-15"), np.datetime64("2023-08-15")],
+    )
+    def test_accepts_mixed_input_types(self, label):
+        w = season_window_from_dates("2023-02-01", "2023-08-31")
+        assert in_season_window(label, w, freq="month")
+
+    def test_day_resolution_is_stricter_at_sub_month_end(self):
+        # freq=None respects the exact end day; the composite path rounds up.
+        w = season_window_from_dates("2023-02-01", "2023-08-10")
+        assert not in_season_window("2023-08-15", w, freq=None)
+        assert in_season_window("2023-08-15", w, freq="month")

--- a/tests/worldcerealtests/test_seasonal.py
+++ b/tests/worldcerealtests/test_seasonal.py
@@ -21,6 +21,7 @@ from worldcereal.train.seasonal import (
     align_to_composite_window,
     composite_window_end,
     date_in_season,
+    enumerate_composite_slots,
     in_season_window,
     resolve_season_bounds,
     season_window_from_dates,
@@ -135,6 +136,29 @@ class TestCompositeWindowEnd:
             start = align_to_composite_window(_d(date), "dekad")
             end = composite_window_end(_d(date), "dekad")
             assert start <= _d(date) <= end
+
+
+class TestEnumerateCompositeSlots:
+    def test_month_inclusive_range(self):
+        slots = enumerate_composite_slots(_d("2023-02-01"), _d("2023-05-01"), "month")
+        assert slots == [_d(s) for s in ("2023-02-01", "2023-03-01", "2023-04-01", "2023-05-01")]
+
+    def test_dekad_range_walks_1_11_21(self):
+        slots = enumerate_composite_slots(_d("2023-08-01"), _d("2023-09-01"), "dekad")
+        assert slots == [
+            _d(s)
+            for s in ("2023-08-01", "2023-08-11", "2023-08-21", "2023-09-01")
+        ]
+
+    def test_single_slot_when_start_equals_end(self):
+        assert enumerate_composite_slots(_d("2023-08-01"), _d("2023-08-01"), "month") == [
+            _d("2023-08-01")
+        ]
+
+    def test_empty_when_end_before_start(self):
+        assert (
+            enumerate_composite_slots(_d("2023-08-01"), _d("2023-02-01"), "month") == []
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Problem**
Crop classes that were well represented in the extractions could end up with near-zero samples after training (e.g. wheat: ~6700 → ~18), surfacing only in the confusion matrix. Root cause: a sample's `in_season` flag is computed against the season-window end trimmed down to the start of its composite (`Aug 31 → Aug 01`), while the exact `valid_time` is compared against it. Any label in the second half of the window's final month (e.g. Aug 15) was marked out-of-season and silently dropped late in `_drop_invalid_samples` - after embeddings were computed.

This was made worse by three places asking _"is this date in the season window?"_ with inconsistent logic: classification app the Tab-3 alignment pre-filter and the manual-window dataset filter used the actual end date (lenient), while the in_season flag used the floored end (strict). So a sample passed alignment, got embeddings, then disappeared.

**Fix**
A single, composite-aware membership rule lives in `worldcereal/train/seasonal.py` and is shared by all three call sites: the season start snaps down to its _composite_ start, the season end snaps up to its _composite_ end (`composite_window_end`), and the exact `valid_time` is compared against that range. This matches the season mask the embedding already uses, and works for both monthly and dekadal compositing.

**Changes**
* `seasonal.py` is now the single home for season/composite primitives.
* `refdata.py`: season-window pre-filter uses `in_season_window(..., freq=freq)`; removed the duplicate `_season_window_membership` and `import calendar`.
* `datasets.py`: in_season flag in `_season_mask_from_window`/`_season_mask_from_calendar` now uses `date_in_season` (coverage gating preserved); removed the duplicate definitions, and the `_advance_composite_slot/_enumerate_composite_slots` wrapper methods (they now live in `seasonal.py`). 
* `test_seasonal.py`: new suite covering the grid primitives, window resolution (incl. year-crossing + day-clamping), and membership.

**Net:** 3 duplicated membership implementations → 1; ~170 lines removed.

**Behavior change**
The alignment pre-filter is now composite-aware (it was day-resolution). For whole-month / whole-dekad windows this is identical to before. It only differs for windows whose edges fall mid-composite, where it now rounds to the composite edge, which is the point: the pre-filter and the in_season flag can no longer disagree.