### PR TITLE
Improved crop calendar fetching for training workflows

### DIFF
--- a/src/worldcereal/data/cropcalendars/__init__.py
+++ b/src/worldcereal/data/cropcalendars/__init__.py
@@ -37,9 +37,9 @@ SEASONALITY_LOOKUP_COLUMNS: Tuple[str, ...] = (
     "annual_eos_dekad"
 )
 SEASONALITY_COLUMN_MAP: Dict[str, Tuple[str, str]] = {
-    "tc-s1": ("s1_sos_doy", "s1_eos_doy"),
-    "tc-s2": ("s2_sos_doy", "s2_eos_doy"),
-    "tc-annual": ("annual_sos_doy", "annual_eos_doy"),
+    "tc-s1": ("s1_sos_dekad", "s1_eos_dekad"),
+    "tc-s2": ("s2_sos_dekad", "s2_eos_dekad"),
+    "tc-annual": ("annual_sos_dekad", "annual_eos_dekad"),
 }
 SEASONALITY_LAT_RANGE = (-89.999, 89.999)
 SEASONALITY_LON_RANGE = (-179.999, 179.999)

--- a/src/worldcereal/seasons.py
+++ b/src/worldcereal/seasons.py
@@ -26,7 +26,7 @@ which returns a TemporalContext object with the start and end dates of the seaso
 import datetime
 import json
 import math
-from typing import Callable, Literal, Optional, Tuple
+from typing import Callable, Literal, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -77,17 +77,12 @@ def _snap_coordinate_to_lookup_grid(
 
 
 def resolve_cropcalendar_columns(
-    season_id: str, parameter: Literal["doy", "dekad"]
+    season_id: str,
 ) -> Tuple[str, str]:
     """Resolve season identifier and parameter to SOS/EOS parquet columns."""
 
-    if parameter not in {"doy", "dekad"}:
-        raise ValueError(
-            f"parameter must be one of ('doy', 'dekad'), got '{parameter}'"
-        )
-
     try:
-        sos_doy_col, eos_doy_col = cropcalendars.SEASONALITY_COLUMN_MAP[season_id]
+        sos_dekad_col, eos_dekad_col = cropcalendars.SEASONALITY_COLUMN_MAP[season_id]
     except KeyError as exc:
         raise ValueError(
             f"Season '{season_id}' is not available in the seasonality lookup. "
@@ -95,8 +90,8 @@ def resolve_cropcalendar_columns(
         ) from exc
 
     return (
-        sos_doy_col.replace("_doy", f"_{parameter}"),
-        eos_doy_col.replace("_doy", f"_{parameter}"),
+        sos_dekad_col,
+        eos_dekad_col,
     )
 
 
@@ -133,16 +128,15 @@ def _extent_to_wgs84_bounds(extent: BoundingBoxExtent) -> Tuple[float, float, fl
     return min(lons), min(lats), max(lons), max(lats)
 
 
-def _fetch_cropcalendar_point(
+def fetch_cropcalendar_dekad_point(
     season_id: str,
     lat: float,
     lon: float,
-    parameter: Literal["doy", "dekad"] = "doy",
     *,
     fallback_to_nearest: bool = True,
     max_fallback_distance_degrees: float = DEFAULT_MAX_FALLBACK_DISTANCE_DEGREES,
 ) -> Tuple[int, int]:
-    """Fetch (SOS, EOS) values for one point from the global parquet lookup.
+    """Fetch (SOS, EOS) dekad values for one point from the global parquet lookup.
 
     The input point is snapped to the lookup's 0.5 deg grid centers before querying.
     If the snapped cell is missing and ``fallback_to_nearest`` is enabled, the
@@ -154,8 +148,6 @@ def _fetch_cropcalendar_point(
         Season identifier (e.g. ``tc-s1``, ``tc-s2``, ``tc-annual``).
     lat, lon : float
         Input point coordinates.
-    parameter : {"doy", "dekad"}, default "doy"
-        Which crop-calendar representation to fetch.
     fallback_to_nearest : bool, default True
         Whether to use the nearest available lookup cell when the snapped cell
         is not present in the table.
@@ -169,7 +161,7 @@ def _fetch_cropcalendar_point(
             "max_fallback_distance_degrees must be a finite non-negative value"
         )
 
-    sos_col, eos_col = resolve_cropcalendar_columns(season_id, parameter)
+    sos_col, eos_col = resolve_cropcalendar_columns(season_id)
 
     table = ensure_seasonality_lookup_table()
     if sos_col not in table.columns or eos_col not in table.columns:
@@ -224,68 +216,12 @@ def _fetch_cropcalendar_point(
     if sos_value <= 0 or eos_value <= 0:
         logger.warning(
             "Seasonality lookup returned nodata values for "
-            f"season '{season_id}' and parameter '{parameter}'."
+            f"season '{season_id}'."
         )
         raise ValueError(
             "Seasonality lookup returned nodata values for "
-            f"season '{season_id}' and parameter '{parameter}'."
+            f"season '{season_id}'."
         )
-
-    return sos_value, eos_value
-
-
-def fetch_cropcalendar_doy_point(
-    season_id: str,
-    lat: float,
-    lon: float,
-    *,
-    fallback_to_nearest: bool = True,
-    max_fallback_distance_degrees: float = DEFAULT_MAX_FALLBACK_DISTANCE_DEGREES,
-) -> Tuple[int, int]:
-    """Fetch (SOS, EOS) DOY values for one point from the global parquet lookup."""
-
-    sos_value, eos_value = _fetch_cropcalendar_point(
-        season_id=season_id,
-        lat=lat,
-        lon=lon,
-        parameter="doy",
-        fallback_to_nearest=fallback_to_nearest,
-        max_fallback_distance_degrees=max_fallback_distance_degrees,
-    )
-
-    if (sos_value > 366 or eos_value > 366):
-        logger.warning(
-            "Seasonality lookup returned invalid DOY values for "
-            f"season '{season_id}': SOS={sos_value}, EOS={eos_value}. "
-            "Valid DOY range is 1-366."
-        )
-        raise ValueError(
-            "Seasonality lookup returned invalid DOY values for "
-            f"season '{season_id}': SOS={sos_value}, EOS={eos_value}. "
-            "Valid DOY range is 1-366."
-        )
-    
-    return sos_value, eos_value
-
-
-def fetch_cropcalendar_dekad_point(
-    season_id: str,
-    lat: float,
-    lon: float,
-    *,
-    fallback_to_nearest: bool = True,
-    max_fallback_distance_degrees: float = DEFAULT_MAX_FALLBACK_DISTANCE_DEGREES,
-) -> Tuple[int, int]:
-    """Fetch (SOS, EOS) dekad values for one point from the global parquet lookup."""
-
-    sos_value, eos_value = _fetch_cropcalendar_point(
-        season_id=season_id,
-        lat=lat,
-        lon=lon,
-        parameter="dekad",
-        fallback_to_nearest=fallback_to_nearest,
-        max_fallback_distance_degrees=max_fallback_distance_degrees,
-    )
 
     if sos_value > 108 or eos_value > 108:
         logger.warning(
@@ -300,6 +236,101 @@ def fetch_cropcalendar_dekad_point(
         )
 
     return sos_value, eos_value
+
+
+def fetch_cropcalendar_dekad_points_batch(
+    season_id: str,
+    lats: np.ndarray,
+    lons: np.ndarray,
+    *,
+    max_fallback_distance_degrees: float = DEFAULT_MAX_FALLBACK_DISTANCE_DEGREES,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Vectorized counterpart of `fetch_cropcalendar_dekad_point` for many points.
+
+    Every point is snapped to the lookup grid and, when the snapped cell is
+    missing, resolved via nearest-cell fallback (mirroring the per-point
+    fallback of `fetch_cropcalendar_dekad_point`, but batched across all
+    input points at once for speed).
+
+    Parameters
+    ----------
+    season_id : str
+        Season identifier (e.g. ``tc-s1``, ``tc-s2``, ``tc-annual``).
+    lats, lons : np.ndarray
+        Input point coordinates.
+    max_fallback_distance_degrees : float, default 5.0
+        Maximum Euclidean distance in latitude/longitude degrees between a
+        snapped coordinate and its fallback lookup cell.
+
+    Returns
+    -------
+    sos, eos : np.ndarray (int64)
+        SOS/EOS dekad values, one per input point. Entries where `invalid`
+        is True hold a placeholder value (1) and must not be used directly.
+    invalid : np.ndarray (bool)
+        True where the lookup returned nodata, an out-of-range dekad, or (when
+        no lookup cell was within `max_fallback_distance_degrees`) no usable
+        fallback was found.
+    """
+    sos_col, eos_col = resolve_cropcalendar_columns(season_id)
+    table = ensure_seasonality_lookup_table()
+    if sos_col not in table.columns or eos_col not in table.columns:
+        raise ValueError(
+            f"Season '{season_id}' requires columns ({sos_col}, {eos_col}) "
+            "but they are not present in the seasonality lookup parquet."
+        )
+
+    lat_arr = np.asarray(lats, dtype=np.float64)
+    lon_arr = np.asarray(lons, dtype=np.float64)
+    lat_c = (
+        np.floor(np.clip(lat_arr, *cropcalendars.SEASONALITY_LAT_RANGE) * 2.0) / 2.0
+    ) + 0.25
+    lon_c = (
+        np.floor(np.clip(lon_arr, *cropcalendars.SEASONALITY_LON_RANGE) * 2.0) / 2.0
+    ) + 0.25
+
+    key_index = pd.MultiIndex.from_arrays([lat_c, lon_c], names=["lat", "lon"])
+    joined = table.reindex(key_index)
+
+    missing = joined[sos_col].isna().to_numpy() | joined[eos_col].isna().to_numpy()
+    if missing.any():
+        lat_vals = table.index.get_level_values("lat").to_numpy()
+        lon_vals = table.index.get_level_values("lon").to_numpy()
+        joined = joined.reset_index(drop=True)
+        missing_pos = np.flatnonzero(missing)
+        missing_cells = {(float(lat_c[i]), float(lon_c[i])) for i in missing_pos}
+        for cell_lat, cell_lon in missing_cells:
+            distances = (lat_vals - cell_lat) ** 2 + (lon_vals - cell_lon) ** 2
+            best_idx = int(distances.argmin())
+            fallback_distance = math.sqrt(float(distances[best_idx]))
+            cell_mask = missing & (lat_c == cell_lat) & (lon_c == cell_lon)
+            if fallback_distance > max_fallback_distance_degrees:
+                logger.error(
+                    "Nearest seasonality lookup cell is too far from snapped "
+                    f"lat/lon ({cell_lat}, {cell_lon}): distance is "
+                    f"{fallback_distance:.3f} degrees, maximum allowed is "
+                    f"{max_fallback_distance_degrees:.3f} degrees."
+                )
+                continue
+            logger.error(
+                f"Seasonality lookup missing ({cell_lat}, {cell_lon}); using "
+                f"nearest cell ({lat_vals[best_idx]}, {lon_vals[best_idx]})."
+            )
+            joined.iloc[np.flatnonzero(cell_mask)] = table.iloc[best_idx]
+
+    sos = joined[sos_col].to_numpy(dtype=np.float64)
+    eos = joined[eos_col].to_numpy(dtype=np.float64)
+    invalid = (
+        ~np.isfinite(sos)
+        | ~np.isfinite(eos)
+        | (sos <= 0)
+        | (eos <= 0)
+        | (sos > 108)
+        | (eos > 108)
+    )
+    sos_i = np.where(invalid, 1, sos).astype(np.int64)
+    eos_i = np.where(invalid, 1, eos).astype(np.int64)
+    return sos_i, eos_i, invalid
 
 
 def fetch_cropcalendar_dekad_extent(
@@ -335,7 +366,7 @@ def _collect_cropcalendar_dekad_extent_values(
     west, south, east, north = _extent_to_wgs84_bounds(extent)
     table = ensure_seasonality_lookup_table()
 
-    sos_col, eos_col = resolve_cropcalendar_columns(season_id, "dekad")
+    sos_col, eos_col = resolve_cropcalendar_columns(season_id)
     if sos_col not in table.columns or eos_col not in table.columns:
         raise ValueError(
             f"Season '{season_id}' requires columns ({sos_col}, {eos_col}) "
@@ -580,95 +611,58 @@ def enrich_production_grid_from_crop_calendars(
     return result
 
 
-def season_doys_to_dates_refyear(sos: int, eos: int, ref_year: int):
-    """Funtion to transform SOS and EOS from DOY
-    to exact dates, making use of the reference year
-    in which EOS should be located.
-
-    Args:
-        sos (int): DOY from SOS
-        eos (int): DOY from EOS
-        ref_year (int): ref year to match
-
-    Returns:
-        tuple: (start_date, end_date)
-    """
-
-    # We can derive the end date from ref_year and EOS
-    end_date = datetime.datetime(ref_year, 1, 1) + pd.Timedelta(days=eos)
-
-    if sos < eos:
-        """
-        Straightforward case where entire season
-        is in calendar year
-        """
-        seasonduration = eos - sos
-
-    else:
-        """
-        Nasty case where we cross a calendar year.
-        """
-
-        # Correct DOY for the year crossing
-        eos += 365
-        seasonduration = eos - sos
-
-    # Now we can compute start date from end date and
-    # season duration
-    start_date = end_date - pd.Timedelta(days=seasonduration)
-
-    return start_date, end_date
-
-
 def season_dekad_to_date(
-    dekad: int, target_year: int = 2000, mode: Optional[Literal["first", "last"]] = None
-) -> datetime.date:
-    """Convert dekad (1-108) to date in a 3-year window around target_year.
-    Attention: 
-    this function always returns first day of the month (first mode) or 
-    last day of the month (last mode) for the dekad."""
+    dekad: Union[int, np.ndarray],
+    target_year: Union[int, np.ndarray] = 2000,
+    mode: Optional[Literal["first", "last"]] = None,
+) -> Union[datetime.date, np.ndarray]:
+    """Convert dekad (1-108) to date(s) in a 3-year window around target_year.
 
-    def dekad_to_month_day(dekad_value):
-        month = (dekad_value - 1) // 3 + 1
-        dekad_in_month = (dekad_value - 1) % 3 + 1
-        return month, dekad_in_month
+    Accepts either scalars (returns a single `datetime.date`) or numpy arrays
+    (returns an array of `datetime64[D]`), so the same implementation serves
+    both per-sample and vectorized/batched code paths.
 
-    if dekad > 36:
-        year_offset = (dekad - 1) // 36
-        year_adjusted = (target_year - 1) + year_offset
-        dekad_adjusted = dekad - year_offset * 36
-    else:
-        year_adjusted = target_year - 1
-        dekad_adjusted = dekad
-
-    month, dk = dekad_to_month_day(dekad_adjusted)
-
-    if mode == "first":
-        day = 1
-        if dk == 3:
-            if month == 12:
-                month = 1
-                year_adjusted += 1
-            else:
-                month += 1
-    elif mode == "last":
-        if dk == 1:
-            if month == 1:
-                month = 12
-                year_adjusted -= 1
-            else:
-                month -= 1
-
-        if month == 2:
-            if (year_adjusted % 4 == 0 and year_adjusted % 100 != 0) or (year_adjusted % 400 == 0):
-                day = 29
-            else:
-                day = 28
-        elif month in [4, 6, 9, 11]:
-            day = 30
-        else:
-            day = 31
-    else:
+    Attention: this function always returns the first day of the month
+    (``mode="first"``) or the last day of the month (``mode="last"``) for the
+    dekad.
+    """
+    if mode not in ("first", "last"):
         raise ValueError("mode must be 'first' or 'last'")
 
-    return datetime.date(year_adjusted, month, day)
+    is_scalar = np.isscalar(dekad) and np.isscalar(target_year)
+    dekad_arr = np.atleast_1d(np.asarray(dekad, dtype=np.int64))
+    year_arr = np.atleast_1d(np.asarray(target_year, dtype=np.int64))
+
+    over36 = dekad_arr > 36
+    year_offset = np.where(over36, (dekad_arr - 1) // 36, 0)
+    year_adj = (year_arr - 1) + year_offset
+    dekad_adj = np.where(over36, dekad_arr - year_offset * 36, dekad_arr)
+    month = (dekad_adj - 1) // 3 + 1
+    dk = (dekad_adj - 1) % 3 + 1
+
+    if mode == "first":
+        is_third = dk == 3
+        is_dec = is_third & (month == 12)
+        month = np.where(is_third, np.where(month == 12, 1, month + 1), month)
+        year_adj = np.where(is_dec, year_adj + 1, year_adj)
+        day = np.ones_like(month)
+    else:  # mode == "last"
+        is_first = dk == 1
+        is_jan = is_first & (month == 1)
+        month = np.where(is_first, np.where(month == 1, 12, month - 1), month)
+        year_adj = np.where(is_jan, year_adj - 1, year_adj)
+        leap = ((year_adj % 4 == 0) & (year_adj % 100 != 0)) | (year_adj % 400 == 0)
+        days_in_month = np.array(
+            [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+        )[month - 1]
+        day = np.where((month == 2) & leap, 29, days_in_month)
+
+    year_epoch = (year_adj - 1970).astype("datetime64[Y]")
+    month_date = year_epoch.astype("datetime64[M]") + (month - 1).astype(
+        "timedelta64[M]"
+    )
+    dates = month_date.astype("datetime64[D]") + (day - 1).astype("timedelta64[D]")
+
+    if is_scalar:
+        return dates[0].item()
+    return dates

--- a/src/worldcereal/train/datasets.py
+++ b/src/worldcereal/train/datasets.py
@@ -29,16 +29,10 @@ from prometheo.predictors import (
 )
 from torch.utils.data import Dataset, Sampler
 
-from worldcereal.data.cropcalendars import (
-    SEASONALITY_LAT_RANGE,
-    SEASONALITY_LON_RANGE,
-    SEASONALITY_LOOKUP_COLUMNS,
-)
 from worldcereal.seasons import (
-    ensure_seasonality_lookup_table,
-    fetch_cropcalendar_doy_point,
-    resolve_cropcalendar_columns,
-    season_doys_to_dates_refyear,
+    fetch_cropcalendar_dekad_point,
+    fetch_cropcalendar_dekad_points_batch,
+    season_dekad_to_date,
 )
 from worldcereal.train import GLOBAL_SEASON_IDS, MIN_EDGE_BUFFER, OUTLIER_COLUMNS
 from worldcereal.train import predictors as _predictor_utils
@@ -171,6 +165,7 @@ def _timestamps_to_datetime_array(timestamps: np.ndarray) -> np.ndarray:
 def _default_season_mask(num_timesteps: int, num_seasons: int) -> np.ndarray:
     num_seasons = max(1, num_seasons)
     return np.ones((num_seasons, num_timesteps), dtype=bool)
+
 
 
 def _resolve_season_engine(
@@ -1903,7 +1898,7 @@ class WorldCerealDataset(Dataset):
         """Fetch (start, end) dates for a season/grid cell from the lookup."""
 
         try:
-            sos_doy, eos_doy = fetch_cropcalendar_doy_point(
+            sos_dekad, eos_dekad = fetch_cropcalendar_dekad_point(
                 season_id=season_id,
                 lat=lat,
                 lon=lon,
@@ -1914,21 +1909,38 @@ class WorldCerealDataset(Dataset):
                 f"{exc} (sample_id={sample_id}, season={season_id})"
             ) from exc
 
-        # For year-crossing seasons (SOS DOY > EOS DOY), season_doys_to_dates_refyear
-        # places the EOS in ref_year. When target_year is derived from label_datetime.year,
-        # this is only correct if the label falls early in the year (before/at EOS DOY).
-        # If the label falls later (after EOS DOY), the relevant season instance ends in
-        # year+1, so we must increment ref_year accordingly.
-        ref_year = year
-        if sos_doy > eos_doy and label_datetime is not None:
-            label_doy = pd.Timestamp(label_datetime).day_of_year
-            if label_doy > eos_doy:
-                ref_year = year + 1
+        # Convert the start and end dekads to actual dates
+        candidate_years = [year - 1, year, year +1]
+        start_dates = [season_dekad_to_date(sos_dekad, target_year=yr, mode="first") for yr in candidate_years]
+        end_dates = [season_dekad_to_date(eos_dekad, target_year=yr, mode="last") for yr in candidate_years]
+    
+        # Select the start and end dates for the season that best matches the label_datetime
+        ## If there is no label_datetime, default to the current year's season
+        ## If there is a label_datetime, we prefer the season that encompasses it
+        ## If no season encompasses the label_datetime, select the closest one
+        if label_datetime is not None:
+            for start_date, end_date in zip(start_dates, end_dates):
+                # Look for encompassing season
+                if start_date <= label_datetime <= end_date:
+                    start_date_fin = start_date
+                    end_date_fin = end_date
+                    break
+            else:
+                # Default to the year for which the distance to the label_datetime is minimal
+                label_diffs_start = [abs((label_datetime - sd).days) for sd in start_dates]
+                label_diffs_end = [abs((label_datetime - ed).days) for ed in end_dates]
+                label_diffs = [min(s, e) for s, e in zip(label_diffs_start, label_diffs_end)]
+                min_diff_idx = label_diffs.index(min(label_diffs))
+                start_date_fin = start_dates[min_diff_idx]
+                end_date_fin = end_dates[min_diff_idx]
+        else:
+            # default to the current year if no label_datetime is provided
+            start_date_fin = start_dates[1]  
+            end_date_fin = end_dates[1]
 
-        start_dt, end_dt = season_doys_to_dates_refyear(sos_doy, eos_doy, ref_year)
         return (
-            np.datetime64(start_dt, "D"),
-            np.datetime64(end_dt, "D"),
+            np.datetime64(start_date_fin, "D"),
+            np.datetime64(end_date_fin, "D"),
         )
 
 
@@ -2479,66 +2491,12 @@ class WorldCerealLabelledDataset(WorldCerealDataset):
         """Precompute per-row, per-season calendar windows (month numbers)."""
         n_rows = len(df)
         seasons = tuple(self._season_ids)
-        for season in seasons:
-            try:
-                resolve_cropcalendar_columns(season, "doy")
-            except ValueError as exc:
-                logger.warning(
-                    f"Fast batched fetching disabled: season {season!r} is not "
-                    f"available in the seasonality lookup ({exc}); using "
-                    "per-sample loading."
-                )
-                return None
 
-        table = ensure_seasonality_lookup_table()
         lat = df["lat"].to_numpy(dtype=np.float64)
         lon = df["lon"].to_numpy(dtype=np.float64)
-        lat_c = (
-            np.floor(
-                np.clip(lat, *SEASONALITY_LAT_RANGE) * 2.0
-            )
-            / 2.0
-        ) + 0.25
-        lon_c = (
-            np.floor(
-                np.clip(lon, *SEASONALITY_LON_RANGE) * 2.0
-            )
-            / 2.0
-        ) + 0.25
-
-        key_index = pd.MultiIndex.from_arrays([lat_c, lon_c], names=["lat", "lon"])
-        joined = table.reindex(key_index)
-
-        # Nearest-cell fallback for grid cells absent from the lookup (mirrors
-        # the per-sample KeyError fallback, logged once per unique cell).
-        missing_rows = joined[
-            list(SEASONALITY_LOOKUP_COLUMNS)
-        ].isna().all(axis=1)
-        if missing_rows.to_numpy().any():
-            lat_vals = table.index.get_level_values("lat").to_numpy()
-            lon_vals = table.index.get_level_values("lon").to_numpy()
-            missing_pos = np.flatnonzero(missing_rows.to_numpy())
-            missing_cells = {(float(lat_c[i]), float(lon_c[i])) for i in missing_pos}
-            cell_to_row = {}
-            for cell_lat, cell_lon in missing_cells:
-                distances = (lat_vals - cell_lat) ** 2 + (lon_vals - cell_lon) ** 2
-                best_idx = int(distances.argmin())
-                cell_to_row[(cell_lat, cell_lon)] = best_idx
-                logger.error(
-                    f"Seasonality lookup missing ({cell_lat}, {cell_lon}); using "
-                    f"nearest cell ({lat_vals[best_idx]}, {lon_vals[best_idx]})."
-                )
-            joined = joined.reset_index(drop=True)
-            for i in missing_pos:
-                joined.iloc[i] = table.iloc[
-                    cell_to_row[(float(lat_c[i]), float(lon_c[i]))]
-                ]
-
         label_days = label_dt.to_numpy().astype("datetime64[D]")
         label_month_num = label_days.astype("datetime64[M]").astype(np.int64)
         label_year = label_days.astype("datetime64[Y]").astype(np.int64) + 1970
-        year_start = label_days.astype("datetime64[Y]").astype("datetime64[D]")
-        label_doy = (label_days - year_start).astype(np.int64) + 1
 
         num_seasons = len(seasons)
         season_start_m = np.zeros((n_rows, num_seasons), dtype=np.int64)
@@ -2548,35 +2506,55 @@ class WorldCerealLabelledDataset(WorldCerealDataset):
         season_in_raw = np.zeros((n_rows, num_seasons), dtype=bool)
 
         for s_idx, season in enumerate(seasons):
-            sos_col, eos_col = resolve_cropcalendar_columns(
-                season, "doy"
-            )
-            if sos_col not in joined.columns or eos_col not in joined.columns:
+            try:
+                sos_i, eos_i, invalid = fetch_cropcalendar_dekad_points_batch(
+                    season, lat, lon
+                )
+            except ValueError as exc:
                 logger.warning(
-                    f"Fast batched fetching disabled: seasonality lookup lacks "
-                    f"columns for season {season!r}; using per-sample loading."
+                    f"Fast batched fetching disabled: season {season!r} is not "
+                    f"available in the seasonality lookup ({exc}); using "
+                    "per-sample loading."
                 )
                 return None
-            sos = joined[sos_col].to_numpy(dtype=np.float64)
-            eos = joined[eos_col].to_numpy(dtype=np.float64)
-            invalid = ~np.isfinite(sos) | ~np.isfinite(eos) | (sos <= 0) | (eos <= 0)
-            sos_i = np.where(invalid, 1, sos).astype(np.int64)
-            eos_i = np.where(invalid, 1, eos).astype(np.int64)
 
-            # For year-crossing seasons, shift ref year when the label falls
-            # after EOS (mirrors _season_context_for).
-            ref_year = label_year + ((sos_i > eos_i) & (label_doy > eos_i)).astype(
-                np.int64
-            )
+            # Mirrors _season_context_for: evaluate the season window for the
+            # three candidate ref years around the label year, prefer the
+            # window that encompasses the label, else fall back to the
+            # nearest one.
+            candidate_years = [label_year - 1, label_year, label_year + 1]
+            start_candidates = [
+                season_dekad_to_date(sos_i, cy, mode="first") for cy in candidate_years
+            ]
+            end_candidates = [
+                season_dekad_to_date(eos_i, cy, mode="last") for cy in candidate_years
+            ]
 
-            # season_doys_to_dates_refyear, vectorized:
-            #   end = Jan 1 of ref_year + eos days; start = end - duration
-            ref_year_start = (
-                (ref_year - 1970).astype("datetime64[Y]").astype("datetime64[D]")
+            encompasses = [
+                (start_candidates[i] <= label_days) & (label_days <= end_candidates[i])
+                for i in range(3)
+            ]
+            selected_idx = np.select(encompasses, [0, 1, 2], default=-1)
+
+            diffs = np.stack(
+                [
+                    np.minimum(
+                        np.abs(
+                            (label_days - start_candidates[i]).astype(np.int64)
+                        ),
+                        np.abs((label_days - end_candidates[i]).astype(np.int64)),
+                    )
+                    for i in range(3)
+                ],
+                axis=0,
             )
-            end_date = ref_year_start + eos_i.astype("timedelta64[D]")
-            duration = np.where(sos_i < eos_i, eos_i - sos_i, eos_i + 365 - sos_i)
-            start_date = end_date - duration.astype("timedelta64[D]")
+            fallback_idx = np.argmin(diffs, axis=0)
+            final_idx = np.where(selected_idx >= 0, selected_idx, fallback_idx)
+
+            start_stack = np.stack(start_candidates, axis=0)
+            end_stack = np.stack(end_candidates, axis=0)
+            start_date = np.take_along_axis(start_stack, final_idx[None, :], axis=0)[0]
+            end_date = np.take_along_axis(end_stack, final_idx[None, :], axis=0)[0]
 
             start_m = start_date.astype("datetime64[M]").astype(np.int64)
             end_m = end_date.astype("datetime64[M]").astype(np.int64)

--- a/tests/worldcerealtests/test_datasets.py
+++ b/tests/worldcerealtests/test_datasets.py
@@ -144,7 +144,7 @@ class TestWorldCerealDataset(unittest.TestCase):
                     True,
                     True,
                     True,
-                    True,
+                    False,
                 ],
             ],
             dtype=bool,

--- a/tests/worldcerealtests/test_season_coverage.py
+++ b/tests/worldcerealtests/test_season_coverage.py
@@ -545,15 +545,15 @@ class TestSeasonContextForYearCrossing:
     Jun-2017–Jan-2018 instead of Jun-2018–Jan-2019.
     """
 
-    # tc-s2 approximate DOYs for southern Chile (year-crossing: SOS > EOS)
-    _SOS_DOY = 156  # ≈ Jun 5
-    _EOS_DOY = 25  # ≈ Jan 25
+    # tc-s2 approximate dekads for southern Chile (year-crossing: SOS > EOS)
+    _SOS_DEKAD = 16  # ≈ Jun 1
+    _EOS_DEKAD = 39  # ≈ Jan 31 of the following year
 
     def _make_lookup_df(self):
         """Minimal seasonality lookup DataFrame for a single cell."""
         lat, lon = -35.0, -71.0  # southern Chile
         return pd.DataFrame(
-            {"s2_sos_doy": [self._SOS_DOY], "s2_eos_doy": [self._EOS_DOY]},
+            {"s2_sos_dekad": [self._SOS_DEKAD], "s2_eos_dekad": [self._EOS_DEKAD]},
             index=pd.MultiIndex.from_tuples([(lat, lon)], names=["lat", "lon"]),
         )
 
@@ -569,8 +569,8 @@ class TestSeasonContextForYearCrossing:
 
         with (
             mock.patch(
-                f"{_datasets_module.__name__}.fetch_cropcalendar_doy_point",
-                return_value=(self._SOS_DOY, self._EOS_DOY),
+                f"{_datasets_module.__name__}.fetch_cropcalendar_dekad_point",
+                return_value=(self._SOS_DEKAD, self._EOS_DEKAD),
             ),
         ):
             return ds._season_context_for(

--- a/tests/worldcerealtests/test_seasons.py
+++ b/tests/worldcerealtests/test_seasons.py
@@ -48,63 +48,50 @@ def test_snap_coordinate_to_lookup_grid_clamps_and_snaps():
 
 
 @pytest.mark.parametrize(
-	("season", "parameter", "expected"),
+	("season", "expected"),
 	[
-		("tc-s1", "doy", ("s1_sos_doy", "s1_eos_doy")),
-		("tc-s2", "dekad", ("s2_sos_dekad", "s2_eos_dekad")),
-		("tc-annual", "doy", ("annual_sos_doy", "annual_eos_doy")),
+		("tc-s1", ("s1_sos_dekad", "s1_eos_dekad")),
+		("tc-s2", ("s2_sos_dekad", "s2_eos_dekad")),
+		("tc-annual", ("annual_sos_dekad", "annual_eos_dekad")),
 	],
 )
-def test_resolve_cropcalendar_columns(season, parameter, expected):
-	assert seasons.resolve_cropcalendar_columns(season, parameter) == expected
+def test_resolve_cropcalendar_columns(season, expected):
+	assert seasons.resolve_cropcalendar_columns(season) == expected
 
 
 def test_resolve_cropcalendar_columns_rejects_unknown_values():
-	with pytest.raises(ValueError, match="parameter"):
-		seasons.resolve_cropcalendar_columns("tc-s1", "month")
 	with pytest.raises(ValueError, match="not available"):
-		seasons.resolve_cropcalendar_columns("tc-unknown", "doy")
+		seasons.resolve_cropcalendar_columns("tc-unknown")
 
 
 def test_fetch_cropcalendar_points_uses_snapped_cell(patched_lookup):
-	assert seasons.fetch_cropcalendar_doy_point("tc-s1", 10.4, 20.4) == (100, 200)
 	assert seasons.fetch_cropcalendar_dekad_point("tc-s2", 10.4, 20.4) == (75, 105)
 
 
 def test_fetch_cropcalendar_point_falls_back_to_nearest_cell(patched_lookup, caplog):
-	result = seasons.fetch_cropcalendar_doy_point("tc-s1", 12, 22)
-
-	assert result == (110, 210)
+	result = seasons.fetch_cropcalendar_dekad_point("tc-s1", 12, 22)
+	assert result == (33, 63)
 
 
 def test_fetch_cropcalendar_point_can_disable_nearest_fallback(patched_lookup):
 	with pytest.raises(ValueError, match="No seasonality record"):
-		seasons.fetch_cropcalendar_doy_point(
+		seasons.fetch_cropcalendar_dekad_point(
 			"tc-s1", 12, 22, fallback_to_nearest=False
 		)
 
 
 def test_fetch_cropcalendar_point_rejects_distant_nearest_cell(patched_lookup):
 	with pytest.raises(ValueError, match="too far"):
-		seasons.fetch_cropcalendar_doy_point(
+		seasons.fetch_cropcalendar_dekad_point(
 			"tc-s1", 12, 22, max_fallback_distance_degrees=1.0
 		)
 
 
-@pytest.mark.parametrize(
-	("function", "column", "invalid_value", "limit"),
-	[
-		(seasons.fetch_cropcalendar_doy_point, "s1_sos_doy", 367, "366"),
-		(seasons.fetch_cropcalendar_dekad_point, "s1_sos_dekad", 109, "108"),
-	],
-)
-def test_fetch_cropcalendar_point_rejects_invalid_values(
-	patched_lookup, function, column, invalid_value, limit
-):
-	patched_lookup.loc[(10.25, 20.25), column] = invalid_value
+def test_fetch_cropcalendar_point_rejects_invalid_values(patched_lookup):
+	patched_lookup.loc[(10.25, 20.25), "s1_sos_dekad"] = 109
 
-	with pytest.raises(ValueError, match=f"Valid .* range is 1-{limit}"):
-		function("tc-s1", 10.4, 20.4)
+	with pytest.raises(ValueError, match="Valid .* range is 1-108"):
+		seasons.fetch_cropcalendar_dekad_point("tc-s1", 10.4, 20.4)
 
 
 def test_fetch_cropcalendar_dekad_extent_returns_medians_and_values(patched_lookup):
@@ -170,20 +157,6 @@ def test_season_dekad_to_date_handles_leap_year_and_invalid_mode():
 	).date()
 	with pytest.raises(ValueError, match="mode"):
 		seasons.season_dekad_to_date(1, mode="middle")
-
-
-@pytest.mark.parametrize(
-	("sos", "eos", "expected_start", "expected_end"),
-	[
-		(100, 200, "2020-04-10", "2020-07-19"),
-		(300, 100, "2019-10-28", "2020-04-10"),
-	],
-)
-def test_season_doys_to_dates_refyear(sos, eos, expected_start, expected_end):
-	start, end = seasons.season_doys_to_dates_refyear(sos, eos, 2020)
-
-	assert start.strftime("%Y-%m-%d") == expected_start
-	assert end.strftime("%Y-%m-%d") == expected_end
 
 
 def test_row_spatial_extent_supports_bbox_schema():


### PR DESCRIPTION
For inference we already moved from DOY's to dekads, now we do the same for the training workflow.

For a training point, the dekad values of SOS and EOS are fetched, then converted to real dates for the relevant year (linked to the label datetime):
- using only the year if no label datetime is provided
- ensuring the label is in the season if possible
- selecting the closest season if the label is outside the season.

As a result, we no longer need the functionality to fetch DOY cropcalendar values, so some functionality was removed.

In addition, I noticed there is a vectorized version available to fetch crop calendar values. This version was out-of-sync with the main implementation and got an update as well.