### PR TITLE
Splitting with children

### DIFF
--- a/src/worldcereal/train/data.py
+++ b/src/worldcereal/train/data.py
@@ -497,21 +497,21 @@ def spatial_train_val_test_split(
 
         # Assign bins to splits in a class-balanced way
         rng = np.random.RandomState(seed)
-        train_bins_list = []
-        val_bins_list = []
-        test_bins_list = []
+        train_bins_list: List[Any] = []
+        val_bins_list: List[Any] = []
+        test_bins_list: List[Any] = []
 
         for cls, cls_bins in class_bins.items():
-            cls_bins = np.array(cls_bins)
-            rng.shuffle(cls_bins)
+            class_bin_array = np.array(cls_bins)
+            rng.shuffle(class_bin_array)
 
-            n_cls_bins = len(cls_bins)
+            n_cls_bins = len(class_bin_array)
             n_cls_test = max(1, int(n_cls_bins * test_size))
             n_cls_val = max(1, int(n_cls_bins * val_size))
 
-            test_bins_list.extend(cls_bins[:n_cls_test])
-            val_bins_list.extend(cls_bins[n_cls_test : n_cls_test + n_cls_val])
-            train_bins_list.extend(cls_bins[n_cls_test + n_cls_val :])
+            test_bins_list.extend(class_bin_array[:n_cls_test])
+            val_bins_list.extend(class_bin_array[n_cls_test : n_cls_test + n_cls_val])
+            train_bins_list.extend(class_bin_array[n_cls_test + n_cls_val :])
 
         test_bins = set(test_bins_list)
         val_bins = set(val_bins_list)
@@ -678,13 +678,14 @@ def dataset_to_embeddings(
                     weights = weights[valid]
                     time_embeddings = time_embeddings[valid]
 
-                encodings = (season_mask_float.unsqueeze(-1) * time_embeddings).sum(
-                    dim=-2
-                ) / torch.clamp(weights, min=1e-6)
-                encodings = encodings.cpu().numpy()
+                pooled_embeddings = (
+                    season_mask_float.unsqueeze(-1) * time_embeddings
+                ).sum(dim=-2) / torch.clamp(weights, min=1e-6)
             else:
                 # Global pooling: simple mean over time dimension
-                encodings = time_embeddings.mean(dim=-2).cpu().numpy()
+                pooled_embeddings = time_embeddings.mean(dim=-2)
+
+            encodings = pooled_embeddings.cpu().numpy()
 
         # Build attributes dataframe
         attrs_frame = {

--- a/src/worldcereal/train/data.py
+++ b/src/worldcereal/train/data.py
@@ -32,7 +32,6 @@ from worldcereal.utils.refdata import (
     DATA_DIR,
     get_class_mappings,
     map_classes,
-    split_df,
 )
 from worldcereal.utils.timeseries import process_parquet
 
@@ -264,6 +263,63 @@ def _collate_attrs(attrs_list: Sequence[dict]) -> dict:
     return collated
 
 
+def _parent_sample_ids(sample_ids: pd.Series) -> pd.Series:
+    """Return the original polygon ID for each sample, including child points."""
+    return sample_ids.astype("string").str.replace(r"_child\d+$", "", regex=True)
+
+
+def _grouped_train_test_split(
+    df: pd.DataFrame,
+    *,
+    test_size: float,
+    seed: int,
+    stratify_label: Optional[str] = None,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Split rows while keeping all children of a sample in one partition."""
+    if "sample_id" not in df.columns:
+        raise ValueError("Grouped splitting requires a 'sample_id' column.")
+
+    parent_ids = _parent_sample_ids(df["sample_id"])
+    grouped = df.assign(_parent_sample_id=parent_ids).groupby(
+        "_parent_sample_id", sort=False
+    )
+    group_df = grouped.first()
+    if stratify_label is not None:
+        inconsistent_labels = grouped[stratify_label].nunique(dropna=False)
+        if (inconsistent_labels > 1).any():
+            invalid_parents = inconsistent_labels[
+                inconsistent_labels > 1
+            ].index.tolist()
+            raise ValueError(
+                f"Parent samples have inconsistent '{stratify_label}' labels: "
+                f"{invalid_parents}"
+            )
+
+    stratify = group_df[stratify_label] if stratify_label is not None else None
+    train_groups, test_groups = train_test_split(
+        group_df,
+        test_size=test_size,
+        random_state=seed,
+        stratify=stratify,
+    )
+    train_mask = parent_ids.isin(train_groups.index)
+    test_mask = parent_ids.isin(test_groups.index)
+    return df[train_mask].copy(), df[test_mask].copy()
+
+
+def _split_by_parent_sample_ids(
+    df: pd.DataFrame, selected_sample_ids: Sequence[str]
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Split by sample IDs, treating child IDs as their parent IDs."""
+    if "sample_id" not in df.columns:
+        raise ValueError("Grouped splitting requires a 'sample_id' column.")
+
+    selected_parents = set(_parent_sample_ids(pd.Series(selected_sample_ids)))
+    parent_ids = _parent_sample_ids(df["sample_id"])
+    is_selected = parent_ids.isin(selected_parents)
+    return df[~is_selected].copy(), df[is_selected].copy()
+
+
 def train_val_test_split(
     df: pd.DataFrame,
     split_column: str = "split",
@@ -294,17 +350,17 @@ def train_val_test_split(
             df, min_samples=min_samples_per_class, class_column=stratify_label
         )
 
-        trn_val_df, tst_df = train_test_split(
+        trn_val_df, tst_df = _grouped_train_test_split(
             df,
             test_size=test_size,
-            random_state=seed,
-            stratify=df[stratify_label],
+            seed=seed,
+            stratify_label=stratify_label,
         )
-        trn_df, val_df = train_test_split(
+        trn_df, val_df = _grouped_train_test_split(
             trn_val_df,
             test_size=val_size / (1.0 - test_size),
-            random_state=seed,
-            stratify=trn_val_df[stratify_label],
+            seed=seed,
+            stratify_label=stratify_label,
         )
         logger.info(
             f"Data split: train={len(trn_df)}, val={len(val_df)}, test={len(tst_df)}"
@@ -378,9 +434,28 @@ def spatial_train_val_test_split(
             df, min_samples=min_samples_per_class, class_column=stratify_label
         )
 
-    # Create spatial bins
-    lat_array = df["lat"].to_numpy(dtype=np.float64)
-    lon_array = df["lon"].to_numpy(dtype=np.float64)
+    # Create one spatial representative per parent so children cannot be
+    # assigned to different bins and therefore different splits.
+    if "sample_id" not in df.columns:
+        raise ValueError("Spatial splitting requires a 'sample_id' column")
+    parent_ids = _parent_sample_ids(df["sample_id"])
+    grouped = df.assign(_parent_sample_id=parent_ids).groupby(
+        "_parent_sample_id", sort=False
+    )
+    group_df = grouped.first()
+    if stratify_label and stratify_label in group_df.columns:
+        inconsistent_labels = grouped[stratify_label].nunique(dropna=False)
+        if (inconsistent_labels > 1).any():
+            invalid_parents = inconsistent_labels[
+                inconsistent_labels > 1
+            ].index.tolist()
+            raise ValueError(
+                f"Parent samples have inconsistent '{stratify_label}' labels: "
+                f"{invalid_parents}"
+            )
+
+    lat_array = group_df["lat"].to_numpy(dtype=np.float64)
+    lon_array = group_df["lon"].to_numpy(dtype=np.float64)
 
     if np.isnan(lat_array).any() or np.isnan(lon_array).any():
         raise ValueError(
@@ -403,14 +478,12 @@ def spatial_train_val_test_split(
         f"(median={int(np.median(bin_counts))})"
     )
 
-    # For stratified bin assignment, compute class distribution per bin
+    # For stratified bin assignment, compute the majority class per bin.
     if stratify_label and stratify_label in df.columns:
-        # Create a mapping of bin -> majority class
         bin_classes = {}
         for bin_id in unique_bins:
-            bin_samples = df[spatial_bins == bin_id]
-            # Use majority class in the bin as the bin's "class"
-            majority_class = bin_samples[stratify_label].mode()[0]
+            bin_samples = group_df[spatial_bins == bin_id]
+            majority_class = group_df.loc[bin_samples.index, stratify_label].mode()[0]
             bin_classes[bin_id] = majority_class
 
         # Group bins by their majority class
@@ -464,13 +537,13 @@ def spatial_train_val_test_split(
         train_bins = set(shuffled_bins[n_test + n_val :])
 
     # Assign samples to splits based on their bin
-    train_mask = np.isin(spatial_bins, list(train_bins))
-    val_mask = np.isin(spatial_bins, list(val_bins))
-    test_mask = np.isin(spatial_bins, list(test_bins))
+    train_groups = group_df.index[np.isin(spatial_bins, list(train_bins))]
+    val_groups = group_df.index[np.isin(spatial_bins, list(val_bins))]
+    test_groups = group_df.index[np.isin(spatial_bins, list(test_bins))]
 
-    trn_df = df[train_mask].copy()
-    val_df = df[val_mask].copy()
-    tst_df = df[test_mask].copy()
+    trn_df = df[parent_ids.isin(train_groups)].copy()
+    val_df = df[parent_ids.isin(val_groups)].copy()
+    tst_df = df[parent_ids.isin(test_groups)].copy()
 
     logger.info(
         f"Spatial split complete: train={len(trn_df)} ({len(train_bins)} bins), "
@@ -1331,15 +1404,15 @@ def get_training_dfs_from_parquet(
             f"Controlled `train/val` vs `test` split based on: {test_samples_file}"
         )
         test_samples_df = pd.read_csv(test_samples_file)
-        trainval_df, test_df = split_df(
-            df, val_sample_ids=test_samples_df.sample_id.tolist()
+        trainval_df, test_df = _split_by_parent_sample_ids(
+            df, test_samples_df.sample_id.tolist()
         )
     else:
         logger.info("Random `train/val` vs `test` split ...")
         # train_df, test_df = split_df(df, val_size=0.2)
         # TO DO: add possibility of per-class stratification to original split_df function
-        trainval_df, test_df = train_test_split(
-            df, test_size=0.2, random_state=42, stratify=df["finetune_class"]
+        trainval_df, test_df = _grouped_train_test_split(
+            df, test_size=0.2, seed=42, stratify_label="finetune_class"
         )
 
     # train_df, val_df = split_df(train_df, val_size=0.2)
@@ -1349,16 +1422,16 @@ def get_training_dfs_from_parquet(
     if val_samples_file is not None:
         logger.info(f"Controlled `train` vs `val` split based on: {val_samples_file}")
         val_samples_df = pd.read_csv(val_samples_file)
-        train_df, val_df = split_df(
-            trainval_df, val_sample_ids=val_samples_df.sample_id.tolist()
+        train_df, val_df = _split_by_parent_sample_ids(
+            trainval_df, val_samples_df.sample_id.tolist()
         )
     else:
         logger.info("Random `train` vs `val` split ...")
-        train_df, val_df = train_test_split(
+        train_df, val_df = _grouped_train_test_split(
             trainval_df,
             test_size=0.2,
-            random_state=42,
-            stratify=trainval_df["finetune_class"],
+            seed=42,
+            stratify_label="finetune_class",
         )
 
     if test_samples_file:

--- a/src/worldcereal/train/data.py
+++ b/src/worldcereal/train/data.py
@@ -32,6 +32,7 @@ from worldcereal.utils.refdata import (
     DATA_DIR,
     get_class_mappings,
     map_classes,
+    parent_sample_ids,
 )
 from worldcereal.utils.timeseries import process_parquet
 
@@ -263,23 +264,14 @@ def _collate_attrs(attrs_list: Sequence[dict]) -> dict:
     return collated
 
 
-def _parent_sample_ids(sample_ids: pd.Series) -> pd.Series:
-    """Return the original polygon ID for each sample, including child points."""
-    return sample_ids.astype("string").str.replace(r"_child\d+$", "", regex=True)
-
-
-def _grouped_train_test_split(
-    df: pd.DataFrame,
-    *,
-    test_size: float,
-    seed: int,
-    stratify_label: Optional[str] = None,
-) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    """Split rows while keeping all children of a sample in one partition."""
+def _parent_groups(
+    df: pd.DataFrame, stratify_label: Optional[str] = None
+) -> Tuple[pd.Series, pd.DataFrame]:
+    """Build one representative row per parent and validate its label."""
     if "sample_id" not in df.columns:
         raise ValueError("Grouped splitting requires a 'sample_id' column.")
 
-    parent_ids = _parent_sample_ids(df["sample_id"])
+    parent_ids = parent_sample_ids(df["sample_id"])
     grouped = df.assign(_parent_sample_id=parent_ids).groupby(
         "_parent_sample_id", sort=False
     )
@@ -294,6 +286,19 @@ def _grouped_train_test_split(
                 f"Parent samples have inconsistent '{stratify_label}' labels: "
                 f"{invalid_parents}"
             )
+
+    return parent_ids, group_df
+
+
+def _grouped_train_test_split(
+    df: pd.DataFrame,
+    *,
+    test_size: float,
+    seed: int,
+    stratify_label: Optional[str] = None,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Split rows while keeping all children of a sample in one partition."""
+    parent_ids, group_df = _parent_groups(df, stratify_label)
 
     stratify = group_df[stratify_label] if stratify_label is not None else None
     train_groups, test_groups = train_test_split(
@@ -314,8 +319,8 @@ def _split_by_parent_sample_ids(
     if "sample_id" not in df.columns:
         raise ValueError("Grouped splitting requires a 'sample_id' column.")
 
-    selected_parents = set(_parent_sample_ids(pd.Series(selected_sample_ids)))
-    parent_ids = _parent_sample_ids(df["sample_id"])
+    selected_parents = set(parent_sample_ids(pd.Series(selected_sample_ids)))
+    parent_ids = parent_sample_ids(df["sample_id"])
     is_selected = parent_ids.isin(selected_parents)
     return df[~is_selected].copy(), df[is_selected].copy()
 
@@ -436,23 +441,9 @@ def spatial_train_val_test_split(
 
     # Create one spatial representative per parent so children cannot be
     # assigned to different bins and therefore different splits.
-    if "sample_id" not in df.columns:
-        raise ValueError("Spatial splitting requires a 'sample_id' column")
-    parent_ids = _parent_sample_ids(df["sample_id"])
-    grouped = df.assign(_parent_sample_id=parent_ids).groupby(
-        "_parent_sample_id", sort=False
+    parent_ids, group_df = _parent_groups(
+        df, stratify_label if stratify_label in df.columns else None
     )
-    group_df = grouped.first()
-    if stratify_label and stratify_label in group_df.columns:
-        inconsistent_labels = grouped[stratify_label].nunique(dropna=False)
-        if (inconsistent_labels > 1).any():
-            invalid_parents = inconsistent_labels[
-                inconsistent_labels > 1
-            ].index.tolist()
-            raise ValueError(
-                f"Parent samples have inconsistent '{stratify_label}' labels: "
-                f"{invalid_parents}"
-            )
 
     lat_array = group_df["lat"].to_numpy(dtype=np.float64)
     lon_array = group_df["lon"].to_numpy(dtype=np.float64)

--- a/src/worldcereal/utils/refdata.py
+++ b/src/worldcereal/utils/refdata.py
@@ -1020,21 +1020,38 @@ def split_df(
     val_size: Optional[float] = None,
     train_only_samples: Optional[List[str]] = None,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    if "sample_id" not in df.columns:
+        raise ValueError("Splitting requires a 'sample_id' column.")
+
+    parent_ids = (
+        df["sample_id"].astype("string").str.replace(r"_child\d+$", "", regex=True)
+    )
+
     if val_size is not None:
         assert (
             (val_countries_iso3 is None)
             and (val_years is None)
             and (val_sample_ids is None)
         )
-        val, train = np.split(
-            df.sample(frac=1, random_state=DEFAULT_SEED), [int(val_size * len(df))]
+        shuffled_parents = parent_ids.drop_duplicates().sample(
+            frac=1, random_state=DEFAULT_SEED
         )
-        logger.info(f"Using {len(train)} train and {len(val)} val samples")
-        return pd.DataFrame(train), pd.DataFrame(val)
+        val_parent_ids = set(
+            shuffled_parents.iloc[: int(val_size * len(shuffled_parents))]
+        )
+        is_val = parent_ids.isin(val_parent_ids)
+        is_train = ~is_val
+        logger.info(f"Using {is_train.sum()} train and {is_val.sum()} val samples")
+        return df[is_train], df[is_val]
     if val_sample_ids is not None:
         assert (val_countries_iso3 is None) and (val_years is None)
-        is_val = df.sample_id.isin(val_sample_ids)
-        is_train = ~df.sample_id.isin(val_sample_ids)
+        val_parent_ids = set(
+            pd.Series(val_sample_ids, dtype="string").str.replace(
+                r"_child\d+$", "", regex=True
+            )
+        )
+        is_val = parent_ids.isin(val_parent_ids)
+        is_train = ~is_val
     elif val_countries_iso3 is not None:
         assert (val_sample_ids is None) and (val_years is None)
         df = join_with_world_df(df)
@@ -1043,25 +1060,33 @@ def split_df(
                 f"Tried removing {country} but it is not in the dataframe"
             )
         if train_only_samples is not None:
-            is_val = df.iso3.isin(val_countries_iso3) & ~df.sample_id.isin(
-                train_only_samples
+            is_val = df.iso3.isin(val_countries_iso3)
+            train_only_parents = set(
+                pd.Series(train_only_samples, dtype="string").str.replace(
+                    r"_child\d+$", "", regex=True
+                )
             )
+            is_val &= ~parent_ids.isin(train_only_parents)
         else:
             is_val = df.iso3.isin(val_countries_iso3)
-        is_train = ~df.iso3.isin(val_countries_iso3)
+        is_val = parent_ids.isin(set(parent_ids[is_val]))
+        is_train = ~is_val
     elif val_years is not None:
         df["end_date_ts"] = pd.to_datetime(df.end_date)
         if train_only_samples is not None:
-            is_val = df.end_date_ts.dt.year.isin(val_years) & ~df.sample_id.isin(
-                train_only_samples
+            is_val = df.end_date_ts.dt.year.isin(val_years)
+            train_only_parents = set(
+                pd.Series(train_only_samples, dtype="string").str.replace(
+                    r"_child\d+$", "", regex=True
+                )
             )
+            is_val &= ~parent_ids.isin(train_only_parents)
         else:
             is_val = df.end_date_ts.dt.year.isin(val_years)
-        is_train = ~df.end_date_ts.dt.year.isin(val_years)
+        is_val = parent_ids.isin(set(parent_ids[is_val]))
+        is_train = ~is_val
 
-    logger.info(
-        f"Using {len(is_val) - sum(is_val)} train and {sum(is_val)} val samples"
-    )
+    logger.info(f"Using {is_train.sum()} train and {is_val.sum()} val samples")
 
     return df[is_train], df[is_val]
 

--- a/src/worldcereal/utils/refdata.py
+++ b/src/worldcereal/utils/refdata.py
@@ -26,6 +26,11 @@ SHAREPOINT_FILE_URL = (
 DATA_DIR = Path(__file__).parent.parent / "data"
 
 
+def parent_sample_ids(sample_ids: pd.Series) -> pd.Series:
+    """Return original polygon IDs for samples, including child points."""
+    return sample_ids.astype("string").str.replace(r"_child\d+$", "", regex=True)
+
+
 def get_class_mappings(
     source: Union[Literal["sharepoint", "local"], str, Path] = "local",
 ) -> Dict:
@@ -1023,9 +1028,7 @@ def split_df(
     if "sample_id" not in df.columns:
         raise ValueError("Splitting requires a 'sample_id' column.")
 
-    parent_ids = (
-        df["sample_id"].astype("string").str.replace(r"_child\d+$", "", regex=True)
-    )
+    parent_ids = parent_sample_ids(df["sample_id"])
 
     if val_size is not None:
         assert (
@@ -1045,11 +1048,7 @@ def split_df(
         return df[is_train], df[is_val]
     if val_sample_ids is not None:
         assert (val_countries_iso3 is None) and (val_years is None)
-        val_parent_ids = set(
-            pd.Series(val_sample_ids, dtype="string").str.replace(
-                r"_child\d+$", "", regex=True
-            )
-        )
+        val_parent_ids = set(parent_sample_ids(pd.Series(val_sample_ids)))
         is_val = parent_ids.isin(val_parent_ids)
         is_train = ~is_val
     elif val_countries_iso3 is not None:
@@ -1061,11 +1060,7 @@ def split_df(
             )
         if train_only_samples is not None:
             is_val = df.iso3.isin(val_countries_iso3)
-            train_only_parents = set(
-                pd.Series(train_only_samples, dtype="string").str.replace(
-                    r"_child\d+$", "", regex=True
-                )
-            )
+            train_only_parents = set(parent_sample_ids(pd.Series(train_only_samples)))
             is_val &= ~parent_ids.isin(train_only_parents)
         else:
             is_val = df.iso3.isin(val_countries_iso3)
@@ -1075,11 +1070,7 @@ def split_df(
         df["end_date_ts"] = pd.to_datetime(df.end_date)
         if train_only_samples is not None:
             is_val = df.end_date_ts.dt.year.isin(val_years)
-            train_only_parents = set(
-                pd.Series(train_only_samples, dtype="string").str.replace(
-                    r"_child\d+$", "", regex=True
-                )
-            )
+            train_only_parents = set(parent_sample_ids(pd.Series(train_only_samples)))
             is_val &= ~parent_ids.isin(train_only_parents)
         else:
             is_val = df.end_date_ts.dt.year.isin(val_years)

--- a/tests/worldcerealtests/test_train.py
+++ b/tests/worldcerealtests/test_train.py
@@ -10,13 +10,108 @@ from worldcereal.train.data import (
     compute_embeddings_from_splits,
     dataset_to_embeddings,
     get_training_dfs_from_parquet,
+    spatial_train_val_test_split,
     train_val_test_split,
 )
 from worldcereal.train.datasets import WorldCerealTrainingDataset
 from worldcereal.train.downstream import TorchTrainer
-from worldcereal.utils.refdata import get_class_mappings
+from worldcereal.utils.refdata import get_class_mappings, split_df
 
 LANDCOVER_KEY = "LANDCOVER10"
+
+
+def _assert_parent_groups_are_disjoint(splits):
+    parent_sets = [
+        set(split["sample_id"].str.replace(r"_child\d+$", "", regex=True))
+        for split in splits
+    ]
+    assert parent_sets[0].isdisjoint(parent_sets[1])
+    assert parent_sets[0].isdisjoint(parent_sets[2])
+    assert parent_sets[1].isdisjoint(parent_sets[2])
+
+
+def test_train_val_test_split_keeps_child_samples_together():
+    rows = []
+    for parent_index in range(20):
+        class_name = "class_a" if parent_index % 2 else "class_b"
+        rows.extend(
+            [
+                {"sample_id": f"parent_{parent_index}", "finetune_class": class_name},
+                {
+                    "sample_id": f"parent_{parent_index}_child1",
+                    "finetune_class": class_name,
+                },
+            ]
+        )
+    df = pd.DataFrame(rows)
+
+    splits = train_val_test_split(
+        df,
+        split_column="missing_split",
+        val_size=0.2,
+        test_size=0.2,
+        min_samples_per_class=2,
+    )
+
+    _assert_parent_groups_are_disjoint(splits)
+    assert sum(len(split) for split in splits) == len(df)
+
+
+def test_spatial_train_val_test_split_keeps_child_samples_together():
+    rows = []
+    for parent_index in range(20):
+        class_name = "class_a" if parent_index % 2 else "class_b"
+        latitude = 10.0 + parent_index * 0.5
+        rows.extend(
+            [
+                {
+                    "sample_id": f"parent_{parent_index}",
+                    "finetune_class": class_name,
+                    "lat": latitude,
+                    "lon": 0.0,
+                },
+                {
+                    "sample_id": f"parent_{parent_index}_child1",
+                    "finetune_class": class_name,
+                    "lat": latitude,
+                    "lon": 0.3,
+                },
+            ]
+        )
+    df = pd.DataFrame(rows)
+
+    splits = spatial_train_val_test_split(
+        df,
+        split_column="missing_split",
+        val_size=0.2,
+        test_size=0.2,
+        bin_size_degrees=0.25,
+        min_samples_per_class=2,
+    )
+
+    _assert_parent_groups_are_disjoint(splits)
+    assert sum(len(split) for split in splits) == len(df)
+
+
+def test_legacy_split_df_keeps_child_samples_together():
+    df = pd.DataFrame(
+        {
+            "sample_id": [
+                "parent_0",
+                "parent_0_child1",
+                "parent_1",
+                "parent_1_child1",
+                "parent_2",
+                "parent_3",
+            ],
+            "end_date": ["2020-01-01"] * 6,
+        }
+    )
+
+    train_df, val_df = split_df(df, val_size=0.5)
+
+    _assert_parent_groups_are_disjoint((train_df, val_df, df.iloc[0:0]))
+    assert len(train_df) + len(val_df) == len(df)
 
 
 def test_worldcerealtraindataset(WorldCerealExtractionsDF):


### PR DESCRIPTION
Prevent train/validation/test leakage when polygon samples have `_child<N>` point samples.

- Group child samples with their parent sample_id before random and spatial splitting.
- Update legacy split_df to preserve parent groups for all split modes.
- Validate that all samples from a parent have the same class label.
- Add regression tests covering random, spatial, and legacy splitting.
