### PR TITLE
update way in which seasons are computed for an extent

### DIFF
--- a/src/worldcereal/seasons.py
+++ b/src/worldcereal/seasons.py
@@ -538,6 +538,7 @@ def fetch_cropcalendar_dekads_extent(
         )
         for sid, (sos_col, eos_col) in columns.items()
     }
+    # Note that here, we are only retaining rows where all requested seasons have valid dekad values.
     retained, row_mask = _jointly_valid_seasons(list(season_ids), valid_masks)
     if not retained or row_mask is None:
         raise ValueError(

--- a/src/worldcereal/seasons.py
+++ b/src/worldcereal/seasons.py
@@ -26,7 +26,17 @@ which returns a TemporalContext object with the start and end dates of the seaso
 import datetime
 import json
 import math
-from typing import Callable, Literal, Optional, Tuple, Union
+from typing import (
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import numpy as np
 import pandas as pd
@@ -38,6 +48,11 @@ from worldcereal.data import cropcalendars
 
 _SEASONALITY_LOOKUP_TABLE: Optional[pd.DataFrame] = None
 DEFAULT_MAX_FALLBACK_DISTANCE_DEGREES = 5.0
+DEFAULT_MAX_DEKAD_DIFFERENCE = 7
+
+# Seasons whose union defines the processing period of a production grid cell.
+PROCESSING_SEASONS: Tuple[str, ...] = ("tc-s1", "tc-s2")
+PROCESSING_PERIOD_MONTHS = 12
 
 
 def ensure_seasonality_lookup_table() -> pd.DataFrame:
@@ -128,6 +143,93 @@ def _extent_to_wgs84_bounds(extent: BoundingBoxExtent) -> Tuple[float, float, fl
     return min(lons), min(lats), max(lons), max(lats)
 
 
+def _lookup_row_for_point(
+    lat: float,
+    lon: float,
+    *,
+    fallback_to_nearest: bool = True,
+    max_fallback_distance_degrees: float = DEFAULT_MAX_FALLBACK_DISTANCE_DEGREES,
+) -> pd.Series:
+    """Return the single lookup row representing a point.
+
+    The point is snapped to the lookup's 0.5 deg grid centers. When the snapped
+    cell is missing and ``fallback_to_nearest`` is enabled, the nearest available
+    cell within ``max_fallback_distance_degrees`` is returned instead.
+    """
+
+    if (
+        not math.isfinite(max_fallback_distance_degrees)
+        or max_fallback_distance_degrees < 0
+    ):
+        raise ValueError(
+            "max_fallback_distance_degrees must be a finite non-negative value"
+        )
+
+    table = ensure_seasonality_lookup_table()
+    lat_center = _snap_coordinate_to_lookup_grid(
+        lat, cropcalendars.SEASONALITY_LAT_RANGE
+    )
+    lon_center = _snap_coordinate_to_lookup_grid(
+        lon, cropcalendars.SEASONALITY_LON_RANGE
+    )
+
+    try:
+        return table.loc[(lat_center, lon_center)]
+    except KeyError as exc:
+        lat_vals = table.index.get_level_values("lat").to_numpy()
+        lon_vals = table.index.get_level_values("lon").to_numpy()
+        if not fallback_to_nearest or lat_vals.size == 0:
+            raise ValueError(
+                "No seasonality record found for snapped lat/lon "
+                f"({lat_center}, {lon_center})."
+            ) from exc
+
+        distances = (lat_vals - lat_center) ** 2 + (lon_vals - lon_center) ** 2
+        best_idx = int(distances.argmin())
+        fallback_distance = math.sqrt(float(distances[best_idx]))
+        if fallback_distance > max_fallback_distance_degrees:
+            raise ValueError(
+                "Nearest seasonality lookup cell is too far from snapped "
+                f"lat/lon ({lat_center}, {lon_center}): distance is "
+                f"{fallback_distance:.3f} degrees, maximum allowed is "
+                f"{max_fallback_distance_degrees:.3f} degrees."
+            ) from exc
+        logger.error(
+            f"Seasonality lookup missing ({lat_center}, {lon_center}); "
+            f"using nearest cell ({lat_vals[best_idx]}, {lon_vals[best_idx]})."
+        )
+        return table.iloc[best_idx]
+
+
+def _in_extent_lookup_rows(extent: BoundingBoxExtent) -> pd.DataFrame:
+    """Return all lookup rows whose cell center falls inside the extent."""
+
+    west, south, east, north = _extent_to_wgs84_bounds(extent)
+    table = ensure_seasonality_lookup_table()
+
+    lat_vals = table.index.get_level_values("lat").to_numpy()
+    lon_vals = table.index.get_level_values("lon").to_numpy()
+    mask_lat = (lat_vals >= south) & (lat_vals <= north)
+    if west <= east:
+        mask_lon = (lon_vals >= west) & (lon_vals <= east)
+    else:
+        mask_lon = (lon_vals >= west) | (lon_vals <= east)
+
+    return table.iloc[np.flatnonzero(mask_lat & mask_lon)]
+
+
+def _require_season_columns(season_id: str, table: pd.DataFrame) -> Tuple[str, str]:
+    """Resolve and validate the SOS/EOS columns of a season."""
+
+    sos_col, eos_col = resolve_cropcalendar_columns(season_id)
+    if sos_col not in table.columns or eos_col not in table.columns:
+        raise ValueError(
+            f"Season '{season_id}' requires columns ({sos_col}, {eos_col}) "
+            "but they are not present in the seasonality lookup parquet."
+        )
+    return sos_col, eos_col
+
+
 def fetch_cropcalendar_dekad_point(
     season_id: str,
     lat: float,
@@ -156,60 +258,15 @@ def fetch_cropcalendar_dekad_point(
         snapped coordinate and a fallback lookup cell.
     """
 
-    if not math.isfinite(max_fallback_distance_degrees) or max_fallback_distance_degrees < 0:
-        raise ValueError(
-            "max_fallback_distance_degrees must be a finite non-negative value"
-        )
-
-    sos_col, eos_col = resolve_cropcalendar_columns(season_id)
-
-    table = ensure_seasonality_lookup_table()
-    if sos_col not in table.columns or eos_col not in table.columns:
-        raise ValueError(
-            f"Season '{season_id}' requires columns ({sos_col}, {eos_col}) "
-            "but they are not present in the seasonality lookup parquet."
-        )
-
-    lat_center = _snap_coordinate_to_lookup_grid(
-        lat, cropcalendars.SEASONALITY_LAT_RANGE
+    sos_col, eos_col = _require_season_columns(
+        season_id, ensure_seasonality_lookup_table()
     )
-    lon_center = _snap_coordinate_to_lookup_grid(
-        lon, cropcalendars.SEASONALITY_LON_RANGE
+    row = _lookup_row_for_point(
+        lat,
+        lon,
+        fallback_to_nearest=fallback_to_nearest,
+        max_fallback_distance_degrees=max_fallback_distance_degrees,
     )
-
-    try:
-        row = table.loc[(lat_center, lon_center)]
-    except KeyError as exc:
-        if not fallback_to_nearest:
-            raise ValueError(
-                "No seasonality record found for snapped lat/lon "
-                f"({lat_center}, {lon_center})."
-            ) from exc
-
-        lat_vals = table.index.get_level_values("lat").to_numpy()
-        lon_vals = table.index.get_level_values("lon").to_numpy()
-        if lat_vals.size == 0:
-            raise ValueError(
-                "No seasonality record found for snapped lat/lon "
-                f"({lat_center}, {lon_center})."
-            ) from exc
-
-        distances = (lat_vals - lat_center) ** 2 + (lon_vals - lon_center) ** 2
-        best_idx = int(distances.argmin())
-        fallback_key = (float(lat_vals[best_idx]), float(lon_vals[best_idx]))
-        fallback_distance = math.sqrt(float(distances[best_idx]))
-        if fallback_distance > max_fallback_distance_degrees:
-            raise ValueError(
-                "Nearest seasonality lookup cell is too far from snapped "
-                f"lat/lon ({lat_center}, {lon_center}): distance is "
-                f"{fallback_distance:.3f} degrees, maximum allowed is "
-                f"{max_fallback_distance_degrees:.3f} degrees."
-            ) from exc
-        logger.error(
-            f"Seasonality lookup missing ({lat_center}, {lon_center}); "
-            f"using nearest cell ({fallback_key[0]}, {fallback_key[1]})."
-        )
-        row = table.iloc[best_idx]
 
     sos_value = int(row[sos_col])
     eos_value = int(row[eos_col])
@@ -333,191 +390,310 @@ def fetch_cropcalendar_dekad_points_batch(
     return sos_i, eos_i, invalid
 
 
-def fetch_cropcalendar_dekad_extent(
-    season_id: str,
-    extent: BoundingBoxExtent,
-    *,
-    fallback_to_nearest: bool = True,
-    max_fallback_distance_degrees: float = DEFAULT_MAX_FALLBACK_DISTANCE_DEGREES,
-) -> Tuple[int, int]:
-    """Fetch median (SOS, EOS) dekad values for an extent from parquet points.
+def _valid_dekad_mask(sos_arr: np.ndarray, eos_arr: np.ndarray) -> np.ndarray:
+    """Mask of entries holding usable dekad values for both SOS and EOS."""
 
-    The function selects lookup points whose lat/lon fall within the extent
-    (reprojected to EPSG:4326 when needed), filters nodata values, and returns
-    median SOS/EOS dekads. If no valid points are found in the extent and
-    ``fallback_to_nearest`` is enabled, it falls back to the extent centroid.
+    return (
+        (sos_arr > 0) & (sos_arr <= 108) & (eos_arr > 0) & (eos_arr <= 108)
+    )
+
+
+def dekad_medoid_index(values: np.ndarray) -> int:
+    """Index of the observed row that best represents all rows.
+
+    `values` holds one row per lookup point and one column per dekad variable
+    (SOS and EOS of every season), so seasons are represented jointly by simply
+    widening the array. The medoid is the row minimising the summed L1 distance
+    to all other rows.
+
+    Aggregating each variable independently (e.g. with a median per column) can
+    yield a season that occurs nowhere in the extent, and whose length is an
+    artefact of mixing distinct seasonality regimes. The medoid instead returns
+    an actually observed row, so both the season lengths and the combination of
+    seasons always remain realistic.
+
+    Distances are plain absolute differences on the 1-108 dekad scale, which
+    keeps the year an observation is anchored to meaningful: dekad 1 and dekad
+    37 are the same time of year but a full year apart, and are treated as such.
     """
 
-    sos_med, eos_med, _, _ = _fetch_cropcalendar_dekad_extent_stats(
-        season_id=season_id,
-        extent=extent,
-        fallback_to_nearest=fallback_to_nearest,
-        max_fallback_distance_degrees=max_fallback_distance_degrees,
+    values = np.atleast_2d(np.asarray(values, dtype=np.int64))
+    if values.shape[0] == 0 or values.shape[1] == 0:
+        raise ValueError("dekad_medoid_index requires a non-empty 2D array.")
+
+    cost = np.zeros(values.shape[0], dtype=np.int64)
+    for column in values.T:
+        cost += np.abs(column[:, None] - column[None, :]).sum(axis=1)
+
+    # Ties are broken on (cost, then each column in order) for reproducibility.
+    keys = tuple(values[:, ::-1].T) + (cost,)
+    return int(np.lexsort(keys)[0])
+
+
+def _jointly_valid_seasons(
+    season_ids: Sequence[str],
+    valid_masks: Mapping[str, np.ndarray],
+) -> Tuple[List[str], Optional[np.ndarray]]:
+    """Largest set of seasons that are jointly valid on at least one row.
+
+    Seasons are added greedily, best covered first, so that regions where a
+    season simply does not exist (nodata) drop that season instead of losing all
+    candidate rows.
+    """
+
+    ordered = sorted(season_ids, key=lambda sid: -int(valid_masks[sid].sum()))
+    retained: List[str] = []
+    mask: Optional[np.ndarray] = None
+    for season_id in ordered:
+        candidate = (
+            valid_masks[season_id] if mask is None else mask & valid_masks[season_id]
+        )
+        if not candidate.any():
+            continue
+        retained.append(season_id)
+        mask = candidate
+
+    return [sid for sid in season_ids if sid in retained], mask
+
+
+def _check_extent_homogeneity(
+    rows: pd.DataFrame,
+    columns: Mapping[str, Tuple[str, str]],
+    max_dekad_difference: int,
+    on_heterogeneity: Literal["warn", "raise"],
+) -> None:
+    """Report seasons whose dekad spread inside the extent is too large."""
+
+    problems = []
+    for season_id, (sos_col, eos_col) in columns.items():
+        for label, column in (("SOS", sos_col), ("EOS", eos_col)):
+            values = rows[column].to_numpy(dtype=np.int64)
+            spread = int(values.max() - values.min())
+            if spread > max_dekad_difference:
+                problems.append(f"{season_id} {label} spans {spread} dekads")
+
+    if not problems:
+        return
+
+    message = (
+        "Seasonality inside the extent is heterogeneous "
+        f"({'; '.join(problems)}; maximum allowed is {max_dekad_difference} "
+        "dekads), so no single crop calendar represents it well. Consider "
+        "downsizing your area of interest."
     )
-    return sos_med, eos_med
+    if on_heterogeneity == "raise":
+        raise ValueError(message)
+    logger.warning(message)
 
 
-def _collect_cropcalendar_dekad_extent_values(
-    season_id: str,
-    extent: BoundingBoxExtent,
-) -> Tuple[np.ndarray, np.ndarray]:
-    """Collect valid in-extent SOS/EOS dekad arrays for a season."""
-
-    west, south, east, north = _extent_to_wgs84_bounds(extent)
-    table = ensure_seasonality_lookup_table()
-
-    sos_col, eos_col = resolve_cropcalendar_columns(season_id)
-    if sos_col not in table.columns or eos_col not in table.columns:
-        raise ValueError(
-            f"Season '{season_id}' requires columns ({sos_col}, {eos_col}) "
-            "but they are not present in the seasonality lookup parquet."
-        )
-
-    lat_vals = table.index.get_level_values("lat").to_numpy()
-    lon_vals = table.index.get_level_values("lon").to_numpy()
-    mask_lat = (lat_vals >= south) & (lat_vals <= north)
-    if west <= east:
-        mask_lon = (lon_vals >= west) & (lon_vals <= east)
-    else:
-        mask_lon = (lon_vals >= west) | (lon_vals <= east)
-    mask = mask_lat & mask_lon
-
-    rows = table.iloc[np.flatnonzero(mask)]
-    if rows.empty:
-        logger.info(
-            "No crop-calendar lookup points found inside extent.")
-        return np.array([], dtype=np.int64), np.array([], dtype=np.int64)
-
-    sos_arr = rows[sos_col].to_numpy(dtype=np.int64)
-    eos_arr = rows[eos_col].to_numpy(dtype=np.int64)
-    valid = (sos_arr > 0) & (sos_arr <= 108) & (eos_arr > 0) & (eos_arr <= 108)
-    sos_valid = sos_arr[valid]
-    eos_valid = eos_arr[valid]
-    if sos_valid.size == 0 or eos_valid.size == 0:
-        logger.warning(
-            "No valid crop-calendar dekad values found inside extent for "
-            f"season '{season_id}' (west={west}, south={south}, east={east}, north={north})."
-        )
-    return sos_valid, eos_valid
-
-
-def _fetch_cropcalendar_dekad_extent_stats(
-    season_id: str,
+def fetch_cropcalendar_dekads_extent(
+    season_ids: Sequence[str],
     extent: BoundingBoxExtent,
     *,
     fallback_to_nearest: bool = True,
     max_fallback_distance_degrees: float = DEFAULT_MAX_FALLBACK_DISTANCE_DEGREES,
-) -> Tuple[int, int, np.ndarray, np.ndarray]:
-    """Return median dekads and in-extent dekad arrays for a season."""
+    max_dekad_difference: int = DEFAULT_MAX_DEKAD_DIFFERENCE,
+    on_heterogeneity: Literal["warn", "raise"] = "warn",
+) -> Dict[str, Tuple[int, int]]:
+    """Fetch representative (SOS, EOS) dekads for several seasons at once.
 
-    sos_arr, eos_arr = _collect_cropcalendar_dekad_extent_values(season_id, extent)
-    if sos_arr.size and eos_arr.size:
-        sos_med = int(np.rint(np.median(sos_arr)))
-        eos_med = int(np.rint(np.median(eos_arr)))
-        return sos_med, eos_med, sos_arr, eos_arr
+    All returned seasons are read from a *single* lookup point, the joint medoid
+    over every requested season. Selecting each season independently could pick
+    season 1 from one seasonality regime and season 2 from another, yielding a
+    cropping calendar that exists nowhere in the extent.
 
-    if not fallback_to_nearest:
+    Seasons that hold nodata everywhere inside the extent are dropped from the
+    result rather than invalidating the whole selection.
+    """
+
+    if not season_ids:
+        raise ValueError("At least one season must be requested.")
+
+    table = ensure_seasonality_lookup_table()
+    columns = {sid: _require_season_columns(sid, table) for sid in season_ids}
+
+    rows = _in_extent_lookup_rows(extent)
+    if rows.empty or not _any_season_valid(rows, columns):
+        if not fallback_to_nearest:
+            raise ValueError(
+                "No valid crop-calendar dekad values found inside extent for "
+                f"seasons {list(season_ids)}."
+            )
+        logger.info(
+            "No valid crop-calendar dekad values found inside extent; "
+            "falling back to nearest lookup point."
+        )
+        centroid_lat, centroid_lon = _extent_centroid(extent)
+        rows = _lookup_row_for_point(
+            centroid_lat,
+            centroid_lon,
+            fallback_to_nearest=True,
+            max_fallback_distance_degrees=max_fallback_distance_degrees,
+        ).to_frame().T
+
+    valid_masks = {
+        sid: _valid_dekad_mask(
+            rows[sos_col].to_numpy(dtype=np.int64),
+            rows[eos_col].to_numpy(dtype=np.int64),
+        )
+        for sid, (sos_col, eos_col) in columns.items()
+    }
+    retained, row_mask = _jointly_valid_seasons(list(season_ids), valid_masks)
+    if not retained or row_mask is None:
         raise ValueError(
-            "No valid crop-calendar dekad values found inside extent for "
-            f"season '{season_id}'."
+            "No valid crop-calendar dekad values found for seasons "
+            f"{list(season_ids)}."
         )
 
-    # Fallback: sample the extent centroid using nearest-cell point lookup.
-    logger.info(
-        "No valid crop-calendar dekad values found inside extent; "
-        "falling back to nearest point."
+    dropped = [sid for sid in season_ids if sid not in retained]
+    if dropped:
+        logger.warning(
+            f"Seasons {dropped} hold no valid crop-calendar values inside the "
+            "extent and are dropped."
+        )
+
+    candidates = rows.iloc[np.flatnonzero(row_mask)]
+    retained_columns = {sid: columns[sid] for sid in retained}
+    _check_extent_homogeneity(
+        candidates, retained_columns, max_dekad_difference, on_heterogeneity
     )
+
+    values = np.column_stack(
+        [
+            candidates[column].to_numpy(dtype=np.int64)
+            for sos_col, eos_col in retained_columns.values()
+            for column in (sos_col, eos_col)
+        ]
+    )
+    medoid = candidates.iloc[dekad_medoid_index(values)]
+    return {
+        sid: (int(medoid[sos_col]), int(medoid[eos_col]))
+        for sid, (sos_col, eos_col) in retained_columns.items()
+    }
+
+
+def _any_season_valid(
+    rows: pd.DataFrame, columns: Mapping[str, Tuple[str, str]]
+) -> bool:
+    """Whether at least one season has a usable value on at least one row."""
+
+    return any(
+        _valid_dekad_mask(
+            rows[sos_col].to_numpy(dtype=np.int64),
+            rows[eos_col].to_numpy(dtype=np.int64),
+        ).any()
+        for sos_col, eos_col in columns.values()
+    )
+
+
+def _extent_centroid(extent: BoundingBoxExtent) -> Tuple[float, float]:
+    """Centroid of an extent in EPSG:4326, handling dateline-crossing bounds."""
+
     west, south, east, north = _extent_to_wgs84_bounds(extent)
     if west <= east:
         centroid_lon = (west + east) / 2.0
     else:
-        # Dateline-crossing extent: midpoint on wrapped interval.
         span = ((east + 360.0) - west) % 360.0
         centroid_lon = ((west + span / 2.0 + 180.0) % 360.0) - 180.0
-    centroid_lat = (south + north) / 2.0
-    sos_med, eos_med = fetch_cropcalendar_dekad_point(
-        season_id=season_id,
-        lat=centroid_lat,
-        lon=centroid_lon,
+    return (south + north) / 2.0, centroid_lon
+
+
+def get_seasons_for_extent(
+    extent: BoundingBoxExtent,
+    year: int,
+    seasons: Sequence[str] = PROCESSING_SEASONS,
+    *,
+    max_dekad_difference: int = DEFAULT_MAX_DEKAD_DIFFERENCE,
+    max_fallback_distance_degrees: float = DEFAULT_MAX_FALLBACK_DISTANCE_DEGREES,
+    on_heterogeneity: Literal["warn", "raise"] = "warn",
+) -> Dict[str, TemporalContext]:
+    """Retrieve the season windows of an extent, jointly across all seasons.
+
+    All returned seasons originate from the same lookup point, so the resulting
+    cropping calendar is one that really occurs inside the extent instead of a
+    mix of seasons taken from different seasonality regimes.
+
+    Args:
+        extent (BoundingBoxExtent): extent for which to infer dates
+        year (int): target year
+        seasons (Sequence[str]): season identifiers to infer
+        max_dekad_difference (int): maximum dekad spread inside the extent before
+            the extent is reported as heterogeneous. Defaults to 7.
+        on_heterogeneity ("warn" | "raise"): whether a too heterogeneous extent
+            is only logged or rejected outright.
+
+    Raises:
+        ValueError: invalid season specified, no valid crop calendar found, or
+            the extent is too heterogeneous while ``on_heterogeneity="raise"``.
+
+    Returns:
+        Dict[str, TemporalContext]: inferred temporal range per season.
+    """
+
+    unsupported = [season for season in seasons if season not in SUPPORTED_SEASONS]
+    if unsupported:
+        raise ValueError(f"Season `{unsupported[0]}` not supported!")
+
+    dekads = fetch_cropcalendar_dekads_extent(
+        seasons,
+        extent,
         fallback_to_nearest=True,
         max_fallback_distance_degrees=max_fallback_distance_degrees,
+        max_dekad_difference=max_dekad_difference,
+        on_heterogeneity=on_heterogeneity,
     )
-    # Expose fallback-derived values in the returned arrays as well, so callers
-    # don't keep receiving empty arrays after a successful fallback.
-    sos_arr = np.array([sos_med], dtype=np.int64)
-    eos_arr = np.array([eos_med], dtype=np.int64)
-    return sos_med, eos_med, sos_arr, eos_arr
+
+    return {
+        season: TemporalContext(
+            season_dekad_to_date(sos, target_year=year, mode="first").strftime(
+                "%Y-%m-%d"
+            ),
+            season_dekad_to_date(eos, target_year=year, mode="last").strftime(
+                "%Y-%m-%d"
+            ),
+        )
+        for season, (sos, eos) in dekads.items()
+    }
 
 
 def get_season_dates_for_extent(
     extent: BoundingBoxExtent,
     year: int,
     season: str = "tc-annual",
-    max_dekad_difference: int = 7,
+    max_dekad_difference: int = DEFAULT_MAX_DEKAD_DIFFERENCE,
     max_fallback_distance_degrees: float = DEFAULT_MAX_FALLBACK_DISTANCE_DEGREES,
 ) -> TemporalContext:
-
     """Function to retrieve seasonality for a specific year based on WorldCereal
-        crop calendars for a given extent and season.
-        
-        Uses `fetch_cropcalendar_dekad_extent` for the median SOS/EOS dekads and
-            converts those to dates via `season_dekad_to_date`.
-        
-        More explanation on the concept of "dekads" can be found at the top of this file.
-    
-        Args:
-            extent (BoundingBoxExtent): extent for which to infer dates
-            year (int): target year
-            season (str): season identifier for which to infer dates. Defaults to `tc-annual`
-            max_dekad_difference (int): maximum difference in seasonality for all pixels
-                    in extent before raising a warning. Defaults to 7.
-    
-        Raises:
-            ValueError: invalid season specified
-            Warning: raised when seasonality difference is too large within the extent
-    
-        Returns:
-            TemporalContext: inferred temporal range
-        """
+    crop calendars for a given extent and season.
 
-    if season not in SUPPORTED_SEASONS:
-        raise ValueError(f"Season `{season}` not supported!")
+    Single-season convenience wrapper around `get_seasons_for_extent`. Use that
+    function directly when several seasons are needed, so they are selected
+    jointly instead of independently.
 
-    sos_dekad, eos_dekad, sos_arr, eos_arr = _fetch_cropcalendar_dekad_extent_stats(
-        season_id=season,
-        extent=extent,
-        fallback_to_nearest=True,
+    More explanation on the concept of "dekads" can be found at the top of this file.
+
+    Args:
+        extent (BoundingBoxExtent): extent for which to infer dates
+        year (int): target year
+        season (str): season identifier for which to infer dates. Defaults to `tc-annual`
+        max_dekad_difference (int): maximum difference in seasonality for all pixels
+                in extent before logging a warning. Defaults to 7.
+
+    Raises:
+        ValueError: invalid season specified or no valid crop calendar found
+
+    Returns:
+        TemporalContext: inferred temporal range
+    """
+
+    contexts = get_seasons_for_extent(
+        extent,
+        year,
+        [season],
+        max_dekad_difference=max_dekad_difference,
         max_fallback_distance_degrees=max_fallback_distance_degrees,
     )
-
-    if sos_arr.size and eos_arr.size:
-        sos_diff = int(sos_arr.max() - sos_arr.min())
-        eos_diff = int(eos_arr.max() - eos_arr.min())
-        warning = False
-        if sos_diff > max_dekad_difference:
-            logger.warning(
-                "Seasonality variability for SOS is large: "
-                f"{sos_diff} dekads (> {max_dekad_difference})."
-            )
-            warning = True
-        if eos_diff > max_dekad_difference:
-            logger.warning(
-                "Seasonality variability for EOS is large: "
-                f"{eos_diff} dekads (> {max_dekad_difference})."
-            )
-            warning = True
-        if warning:
-            logger.warning(
-                "Computation of median crop calendars may be inaccurate. "
-                "Consider downsizing your area of interest for more accurate results."
-            )
-
-    start_date = season_dekad_to_date(sos_dekad, target_year=year, mode="first")
-    end_date = season_dekad_to_date(eos_dekad, target_year=year, mode="last")
-
-    return TemporalContext(
-        start_date.strftime("%Y-%m-%d"), end_date.strftime("%Y-%m-%d")
-    )
+    return contexts[season]
 
 
 def _row_spatial_extent_from_grid_row(row: pd.Series) -> BoundingBoxExtent:
@@ -573,18 +749,154 @@ def _row_spatial_extent_from_grid_row(row: pd.Series) -> BoundingBoxExtent:
     )
 
 
+def _month_index(value: Union[str, datetime.date, pd.Timestamp]) -> int:
+    """Map a date to a continuous month index (year * 12 + month - 1)."""
+
+    ts = pd.Timestamp(value)
+    return ts.year * 12 + (ts.month - 1)
+
+
+def _month_start_date(month_index: int) -> datetime.date:
+    """First calendar day of the month identified by `month_index`."""
+
+    year, month = divmod(month_index, 12)
+    return datetime.date(year, month + 1, 1)
+
+
+def _month_end_date(month_index: int) -> datetime.date:
+    """Last calendar day of the month identified by `month_index`."""
+
+    return (pd.Timestamp(_month_start_date(month_index)) + pd.offsets.MonthEnd(1)).date()
+
+
+def consolidate_processing_period(
+    season_windows: Mapping[str, Sequence[str]],
+    *,
+    period_months: int = PROCESSING_PERIOD_MONTHS,
+) -> TemporalContext:
+    """Derive a processing period of exactly `period_months` from season windows.
+
+    The period is anchored on the union of all provided season windows, so start
+    and end dates can never contradict the seasons they are supposed to cover.
+    Because season windows always start on the first and end on the last day of a
+    month, the consolidation is done on whole months, which makes the resulting
+    period exactly `period_months` long by construction.
+
+    When the union is shorter than `period_months`, it is padded symmetrically
+    (any odd month goes to the end). When it is longer, it is trimmed
+    symmetrically and a warning is raised, since at least one season will then
+    only be partially covered.
+
+    Args:
+        season_windows: mapping of season id to a ``(start_date, end_date)`` pair
+            of ``YYYY-MM-DD`` strings.
+        period_months: required length of the processing period, in months.
+
+    Returns:
+        TemporalContext: consolidated processing period.
+    """
+
+    if not season_windows:
+        raise ValueError(
+            "Cannot consolidate a processing period without any season window."
+        )
+    if period_months <= 0:
+        raise ValueError("period_months must be a strictly positive number of months.")
+
+    first_month = min(_month_index(window[0]) for window in season_windows.values())
+    last_month = max(_month_index(window[1]) for window in season_windows.values())
+    span = last_month - first_month + 1
+
+    if span > period_months:
+        logger.warning(
+            f"Union of seasons {sorted(season_windows)} spans {span} months, which "
+            f"exceeds the required processing period of {period_months} months. "
+            "The period is trimmed symmetrically; seasons will be partially covered."
+        )
+        first_month += (span - period_months) // 2
+    elif span < period_months:
+        first_month -= (period_months - span) // 2
+    last_month = first_month + period_months - 1
+
+    return TemporalContext(
+        _month_start_date(first_month).strftime("%Y-%m-%d"),
+        _month_end_date(last_month).strftime("%Y-%m-%d"),
+    )
+
+
+def clip_season_windows_to_period(
+    season_windows: Mapping[str, Sequence[str]],
+    processing_period: TemporalContext,
+) -> dict:
+    """Clip season windows to `processing_period` so no season sticks out of it.
+
+    Seasons that end up fully outside the period are dropped, since they cannot
+    be produced from the data covered by the processing period.
+
+    Args:
+        season_windows: mapping of season id to a ``(start_date, end_date)`` pair
+            of ``YYYY-MM-DD`` strings.
+        processing_period: processing period the seasons have to fit in.
+
+    Returns:
+        dict: clipped season windows, keyed by season id.
+    """
+
+    period_first = _month_index(processing_period.start_date)
+    period_last = _month_index(processing_period.end_date)
+
+    clipped = {}
+    for season_id, (start, end) in season_windows.items():
+        first = max(_month_index(start), period_first)
+        last = min(_month_index(end), period_last)
+        if first > last:
+            logger.warning(
+                f"Season '{season_id}' ({start} - {end}) lies fully outside the "
+                f"processing period {processing_period.start_date} - {processing_period.end_date} "
+                "and is dropped."
+            )
+            continue
+        clipped[season_id] = [
+            _month_start_date(first).strftime("%Y-%m-%d"),
+            _month_end_date(last).strftime("%Y-%m-%d"),
+        ]
+        if clipped[season_id] != [start, end]:
+            logger.warning(
+                f"Season '{season_id}' is clipped from ({start} - {end}) to "
+                f"({clipped[season_id][0]} - {clipped[season_id][1]}) to fit the "
+                "processing period."
+            )
+
+    return clipped
+
+
 def enrich_production_grid_from_crop_calendars(
     grid_df: pd.DataFrame,
     year: int,
     *,
     get_seasons: bool = True,
     extent_resolver: Optional[Callable[[pd.Series], BoundingBoxExtent]] = None,
+    seasons: Sequence[str] = PROCESSING_SEASONS,
+    period_months: int = PROCESSING_PERIOD_MONTHS,
+    max_dekad_difference: int = DEFAULT_MAX_DEKAD_DIFFERENCE,
+    on_heterogeneity: Literal["warn", "raise"] = "raise",
 ) -> pd.DataFrame:
     """Enrich a production grid with temporal extent and optional season metadata.
 
+    All seasons of a grid cell are resolved jointly from a single crop-calendar
+    point, and ``start_date`` / ``end_date`` are then derived from their union
+    via `consolidate_processing_period`. This guarantees a processing period of
+    exactly ``period_months`` months that is always consistent with the seasons
+    it has to cover. The season windows are subsequently clipped to that period,
+    so seasons and processing period always remain mutually consistent.
+
+    Cells whose seasonality is too heterogeneous to be represented by a single
+    crop calendar are rejected by default, since silently producing them would
+    yield a calendar that applies nowhere in the cell.
+
     This function writes:
-    - ``start_date`` and ``end_date`` from ``tc-annual`` crop calendars.
-    - optionally ``season_ids`` and ``season_windows`` (JSON string) seasons 1 and 2.
+    - ``start_date`` and ``end_date``, consolidated from the season windows.
+    - optionally ``season_ids`` and ``season_windows`` (JSON string).
     """
 
     resolver = extent_resolver or _row_spatial_extent_from_grid_row
@@ -592,20 +904,30 @@ def enrich_production_grid_from_crop_calendars(
 
     for idx, row in result.iterrows():
         extent = resolver(row)
-        annual_ctx = get_season_dates_for_extent(extent, year, "tc-annual")
-        result.loc[idx, "start_date"] = annual_ctx.start_date
-        result.loc[idx, "end_date"] = annual_ctx.end_date
+
+        season_contexts = get_seasons_for_extent(
+            extent,
+            year,
+            seasons,
+            max_dekad_difference=max_dekad_difference,
+            on_heterogeneity=on_heterogeneity,
+        )
+        season_windows = {
+            season: [context.start_date, context.end_date]
+            for season, context in season_contexts.items()
+        }
+
+        processing_ctx = consolidate_processing_period(
+            season_windows, period_months=period_months
+        )
+        result.loc[idx, "start_date"] = processing_ctx.start_date
+        result.loc[idx, "end_date"] = processing_ctx.end_date
 
         if not get_seasons:
             continue
 
-        season_windows = {}
-        for season in ["tc-s1", "tc-s2"]:
-            season_ctx = get_season_dates_for_extent(extent, year, season)
-            season_windows[season] = [season_ctx.start_date, season_ctx.end_date]
-
-        season_ids = sorted(season_windows.keys())
-        result.loc[idx, "season_ids"] = ",".join(season_ids)
+        season_windows = clip_season_windows_to_period(season_windows, processing_ctx)
+        result.loc[idx, "season_ids"] = ",".join(sorted(season_windows))
         result.loc[idx, "season_windows"] = json.dumps(season_windows, sort_keys=True)
 
     return result

--- a/src/worldcereal/seasons.py
+++ b/src/worldcereal/seasons.py
@@ -783,10 +783,10 @@ def consolidate_processing_period(
     month, the consolidation is done on whole months, which makes the resulting
     period exactly `period_months` long by construction.
 
-    When the union is shorter than `period_months`, it is padded symmetrically
-    (any odd month goes to the end). When it is longer, it is trimmed
-    symmetrically and a warning is raised, since at least one season will then
-    only be partially covered.
+    When the union is shorter than `period_months`, the period ends at the end
+    of the latest season and is extended backwards to the required length. When
+    it is longer, it is trimmed symmetrically and a warning is raised, since at
+    least one season will then only be partially covered.
 
     Args:
         season_windows: mapping of season id to a ``(start_date, end_date)`` pair
@@ -816,7 +816,7 @@ def consolidate_processing_period(
         )
         first_month += (span - period_months) // 2
     elif span < period_months:
-        first_month -= (period_months - span) // 2
+        first_month = last_month - period_months + 1
     last_month = first_month + period_months - 1
 
     return TemporalContext(

--- a/tests/worldcerealtests/test_seasons.py
+++ b/tests/worldcerealtests/test_seasons.py
@@ -94,38 +94,51 @@ def test_fetch_cropcalendar_point_rejects_invalid_values(patched_lookup):
 		seasons.fetch_cropcalendar_dekad_point("tc-s1", 10.4, 20.4)
 
 
-def test_fetch_cropcalendar_dekad_extent_returns_medians_and_values(patched_lookup):
+def test_fetch_cropcalendar_dekads_extent_returns_medoid(patched_lookup):
 	extent = BoundingBoxExtent(west=20, south=10, east=22, north=11, epsg=4326)
 
-	assert seasons.fetch_cropcalendar_dekad_extent("tc-s1", extent) == (32, 62)
+	assert seasons.fetch_cropcalendar_dekads_extent(["tc-s1"], extent) == {
+		"tc-s1": (30, 60)
+	}
 
 
-def test_fetch_cropcalendar_dekad_extent_handles_dateline(patched_lookup):
+def test_fetch_cropcalendar_dekads_extent_handles_dateline(patched_lookup):
 	extent = BoundingBoxExtent(west=179, south=11, east=-179, north=12, epsg=4326)
 
-	assert seasons.fetch_cropcalendar_dekad_extent("tc-s1", extent) == (38, 68)
+	assert seasons.fetch_cropcalendar_dekads_extent(["tc-s1"], extent) == {
+		"tc-s1": (36, 66)
+	}
 
 
-def test_fetch_cropcalendar_dekad_extent_falls_back_to_centroid(patched_lookup):
+def test_fetch_cropcalendar_dekads_extent_falls_back_to_centroid(patched_lookup):
 	extent = BoundingBoxExtent(
 		west=20.5, south=10.5, east=20.75, north=10.75, epsg=4326
 	)
 
-	assert seasons.fetch_cropcalendar_dekad_extent("tc-s1", extent) == (30, 60)
+	assert seasons.fetch_cropcalendar_dekads_extent(["tc-s1"], extent) == {
+		"tc-s1": (30, 60)
+	}
 
 
-def test_fetch_cropcalendar_dekad_extent_rejects_distant_centroid(patched_lookup):
+def test_fetch_cropcalendar_dekads_extent_rejects_distant_centroid(patched_lookup):
 	extent = BoundingBoxExtent(west=30, south=30, east=31, north=31, epsg=4326)
 
 	with pytest.raises(ValueError, match="too far"):
-		seasons.fetch_cropcalendar_dekad_extent("tc-s1", extent)
+		seasons.fetch_cropcalendar_dekads_extent(["tc-s1"], extent)
+
+
+def test_fetch_cropcalendar_dekads_extent_requires_a_season(patched_lookup):
+	extent = BoundingBoxExtent(west=20, south=10, east=22, north=11, epsg=4326)
+
+	with pytest.raises(ValueError, match="At least one season"):
+		seasons.fetch_cropcalendar_dekads_extent([], extent)
 
 
 def test_get_season_dates_for_extent_returns_temporal_context(patched_lookup):
 	extent = BoundingBoxExtent(west=20, south=10, east=22, north=11, epsg=4326)
 
 	assert seasons.get_season_dates_for_extent(extent, 2024, "tc-s1") == TemporalContext(
-		"2023-11-01", "2024-09-30"
+		"2023-11-01", "2024-08-31"
 	)
 
 
@@ -179,21 +192,159 @@ def test_enrich_production_grid_from_crop_calendars(patched_lookup):
 
 	enriched = seasons.enrich_production_grid_from_crop_calendars(grid, 2024)
 
-	assert enriched.loc[0, "start_date"] == "2023-05-01"
-	assert enriched.loc[0, "end_date"] == "2025-07-31"
+	# Union of both seasons spans 25 months, so it is trimmed symmetrically to 12
+	# and the individual seasons are clipped to that period.
+	assert enriched.loc[0, "start_date"] == "2024-05-01"
+	assert enriched.loc[0, "end_date"] == "2025-04-30"
 	assert enriched.loc[0, "season_ids"] == "tc-s1,tc-s2"
 	assert json.loads(enriched.loc[0, "season_windows"]) == {
-		"tc-s1": ["2023-11-01", "2024-09-30"],
-		"tc-s2": ["2025-02-01", "2025-11-30"],
+		"tc-s1": ["2024-05-01", "2024-08-31"],
+		"tc-s2": ["2025-02-01", "2025-04-30"],
 	}
 
 
-def test_collect_cropcalendar_values_filters_nodata(patched_lookup):
+def test_dekad_medoid_index_returns_an_observed_row():
+	# Two disagreeing regimes: a short early season and a long late one.
+	# Independent medians would yield (16, 30), a 15-dekad season that occurs
+	# nowhere in the extent, while both real regimes last 10 resp. 19 dekads.
+	values = np.array([[10, 19], [11, 20], [22, 40], [23, 41]])
+
+	assert seasons.dekad_medoid_index(values) == 1
+
+
+def test_dekad_medoid_index_keeps_year_offsets_distinct():
+	# Three seasons in one year and two in the next: a circular metric would
+	# collapse both groups, a linear one keeps the majority group.
+	values = np.array([[2, 14], [3, 15], [4, 16], [38, 50], [39, 51]])
+
+	assert seasons.dekad_medoid_index(values) == 2
+
+
+def test_dekad_medoid_index_rejects_empty_input():
+	with pytest.raises(ValueError, match="non-empty 2D array"):
+		seasons.dekad_medoid_index(np.empty((0, 2)))
+
+
+@pytest.fixture
+def two_regime_lookup(monkeypatch):
+	"""Extent holding two seasonality regimes that disagree per season."""
+
+	table = pd.DataFrame(
+		{
+			"s1_sos_dekad": [10, 11, 12, 40],
+			"s1_eos_dekad": [19, 20, 21, 60],
+			"s2_sos_dekad": [90, 60, 61, 62],
+			"s2_eos_dekad": [99, 70, 71, 72],
+		},
+		index=pd.MultiIndex.from_tuples(
+			[(10.25, 20.25), (10.25, 21.25), (10.25, 22.25), (10.25, 23.25)],
+			names=["lat", "lon"],
+		),
+	)
+	monkeypatch.setattr(seasons, "ensure_seasonality_lookup_table", lambda: table)
+	return table
+
+
+def test_fetch_cropcalendar_dekads_extent_selects_seasons_jointly(two_regime_lookup):
+	extent = BoundingBoxExtent(west=20, south=10, east=24, north=11, epsg=4326)
+
+	# Taken on its own, season 1 is best represented by the second point ...
+	assert seasons.fetch_cropcalendar_dekads_extent(["tc-s1"], extent) == {
+		"tc-s1": (11, 20)
+	}
+	# ... but jointly both seasons come from the third point, so the returned
+	# cropping calendar is one that really occurs somewhere in the extent.
+	assert seasons.fetch_cropcalendar_dekads_extent(["tc-s1", "tc-s2"], extent) == {
+		"tc-s1": (12, 21),
+		"tc-s2": (61, 71),
+	}
+
+
+def test_fetch_cropcalendar_dekads_extent_can_reject_heterogeneous_extent(
+	two_regime_lookup,
+):
+	extent = BoundingBoxExtent(west=20, south=10, east=24, north=11, epsg=4326)
+
+	with pytest.raises(ValueError, match="heterogeneous"):
+		seasons.fetch_cropcalendar_dekads_extent(
+			["tc-s1", "tc-s2"], extent, on_heterogeneity="raise"
+		)
+
+
+def test_fetch_cropcalendar_dekads_extent_drops_nodata_season(two_regime_lookup):
+	two_regime_lookup["s2_sos_dekad"] = 0
+	extent = BoundingBoxExtent(west=20, south=10, east=24, north=11, epsg=4326)
+
+	assert seasons.fetch_cropcalendar_dekads_extent(["tc-s1", "tc-s2"], extent) == {
+		"tc-s1": (11, 20)
+	}
+
+
+def test_enrich_production_grid_rejects_heterogeneous_cell(two_regime_lookup):
+	grid = pd.DataFrame(
+		{"xmin": [20], "ymin": [10], "xmax": [24], "ymax": [11], "epsg": [4326]}
+	)
+
+	with pytest.raises(ValueError, match="heterogeneous"):
+		seasons.enrich_production_grid_from_crop_calendars(grid, 2024)
+
+
+def test_clip_season_windows_to_period_clips_and_drops():
+	period = TemporalContext("2024-03-01", "2025-02-28")
+	season_windows = {
+		"tc-s1": ["2023-11-01", "2024-09-30"],
+		"tc-s2": ["2024-04-01", "2024-08-31"],
+		"tc-s3": ["2025-03-01", "2025-08-31"],
+	}
+
+	assert seasons.clip_season_windows_to_period(season_windows, period) == {
+		"tc-s1": ["2024-03-01", "2024-09-30"],
+		"tc-s2": ["2024-04-01", "2024-08-31"],
+	}
+
+
+@pytest.mark.parametrize(
+	("season_windows", "expected"),
+	[
+		# Union already exactly 12 months: kept as is.
+		(
+			{"tc-s1": ["2024-03-01", "2024-08-31"], "tc-s2": ["2024-09-01", "2025-02-28"]},
+			("2024-03-01", "2025-02-28"),
+		),
+		# Shorter union: padded symmetrically, odd month goes to the end.
+		(
+			{"tc-s1": ["2024-04-01", "2024-10-31"]},
+			("2024-02-01", "2025-01-31"),
+		),
+		# Single season already longer than 12 months: trimmed symmetrically.
+		(
+			{"tc-s1": ["2024-01-01", "2025-02-28"]},
+			("2024-02-01", "2025-01-31"),
+		),
+	],
+)
+def test_consolidate_processing_period_always_spans_twelve_months(
+	season_windows, expected
+):
+	context = seasons.consolidate_processing_period(season_windows)
+
+	assert (context.start_date, context.end_date) == expected
+	start = pd.Timestamp(context.start_date)
+	assert pd.Timestamp(context.end_date) + pd.Timedelta(days=1) == start + pd.DateOffset(
+		years=1
+	)
+
+
+def test_consolidate_processing_period_requires_season_windows():
+	with pytest.raises(ValueError, match="without any season window"):
+		seasons.consolidate_processing_period({})
+
+
+def test_fetch_cropcalendar_dekads_extent_filters_nodata(patched_lookup):
 	patched_lookup.loc[(10.25, 20.25), "s1_sos_dekad"] = 0
 	extent = BoundingBoxExtent(west=20, south=10, east=21.5, north=11, epsg=4326)
 
-	sos, eos = seasons._collect_cropcalendar_dekad_extent_values("tc-s1", extent)
-
-	np.testing.assert_array_equal(sos, np.array([33]))
-	np.testing.assert_array_equal(eos, np.array([63]))
+	assert seasons.fetch_cropcalendar_dekads_extent(["tc-s1"], extent) == {
+		"tc-s1": (33, 63)
+	}
 

--- a/tests/worldcerealtests/test_seasons.py
+++ b/tests/worldcerealtests/test_seasons.py
@@ -311,10 +311,10 @@ def test_clip_season_windows_to_period_clips_and_drops():
 			{"tc-s1": ["2024-03-01", "2024-08-31"], "tc-s2": ["2024-09-01", "2025-02-28"]},
 			("2024-03-01", "2025-02-28"),
 		),
-		# Shorter union: padded symmetrically, odd month goes to the end.
+		# Shorter union: ends with the latest season and extends backwards.
 		(
 			{"tc-s1": ["2024-04-01", "2024-10-31"]},
-			("2024-02-01", "2025-01-31"),
+			("2023-11-01", "2024-10-31"),
 		),
 		# Single season already longer than 12 months: trimmed symmetrically.
 		(


### PR DESCRIPTION
Updated the way in which we derive seasonality for a given spatial extent from the global seasonality parquet.

Previously we just treated each season independently: compute median SOS and EOS for both S1 and S2 and that's it.
this could lead to various issues
-median resulting in a value which didn't exist in the crop calendars
- if you happen to be on the edge of two different seasonality regimes, you might up combining S1 from 1 regime with S2 from another regime, which would not make sense
- union of both seasons might be more or less than 12 months (what we saw in Europe)

So I tried to work on a solution covering all these points in this PR:
 
-instead of using the median, we use the concept of the medoid (no making up of seasons, we pick a season that is guaranteed to exist amongst the points coinciding with the extent)
- instead of treating every season separately, we compute for a given extent which PAIR of EXISTING seasons best represents the extent
- when we populate a production grid and we notice season heterogeneity is too large, we RAISE instead of issuing a warning
- only when the two seasons have been selected, we compute the processing extent as the union of both seasons. There are additional checks in place in case the union is longer or shorter than 12 months (which should actually no longer be the case at this point, but you never know...)